### PR TITLE
Publishing /imu/data at high rate 

### DIFF
--- a/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
+++ b/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
@@ -143,7 +143,7 @@
         pub_mag: true
         pub_temperature: true
         pub_pressure: true
-        pub_accelerationhr: false #High Rate Data Acceleration, when this is true, set enable_high_rate to true as well
+        pub_acceleration_hr: false #High Rate Data Acceleration, when this is true, set enable_high_rate to true as well
         pub_angular_velocity_hr: false #High Rate Data Angular Velocity,  when this is true, set enable_high_rate to true as well
         pub_transform: true
         pub_status: true

--- a/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
+++ b/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
@@ -132,6 +132,7 @@
         pub_utctime: true
         pub_sampletime: true
         pub_imu: true
+        pub_imu_hr: true
         pub_quaternion: true
         pub_euler: true
         pub_free_acceleration: true

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationhrpublisher.h
@@ -44,7 +44,9 @@ struct AccelerationHRPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/acceleration_hr", pub_queue_size);
+        rclcpp::QoS qos = rclcpp::SensorDataQoS();
+        qos.keep_last(pub_queue_size); 
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/acceleration_hr", qos);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocityhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocityhrpublisher.h
@@ -44,7 +44,9 @@ struct AngularVelocityHRPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/angular_velocity_hr", pub_queue_size);
+        rclcpp::QoS qos = rclcpp::SensorDataQoS();
+        qos.keep_last(pub_queue_size); 
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/angular_velocity_hr", qos);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/imuhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/imuhrpublisher.h
@@ -1,0 +1,165 @@
+//  Copyright (c) 2003-2024 Movella Technologies B.V. or subsidiaries worldwide.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  
+//  1.	Redistributions of source code must retain the above copyright notice,
+//  	this list of conditions, and the following disclaimer.
+//  
+//  2.	Redistributions in binary form must reproduce the above copyright notice,
+//  	this list of conditions, and the following disclaimer in the documentation
+//  	and/or other materials provided with the distribution.
+//  
+//  3.	Neither the names of the copyright holders nor the names of their contributors
+//  	may be used to endorse or promote products derived from this software without
+//  	specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+//  THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+//  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR
+//  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.THE LAWS OF THE NETHERLANDS 
+//  SHALL BE EXCLUSIVELY APPLICABLE AND ANY DISPUTES SHALL BE FINALLY SETTLED UNDER THE RULES 
+//  OF ARBITRATION OF THE INTERNATIONAL CHAMBER OF COMMERCE IN THE HAGUE BY ONE OR MORE 
+//  ARBITRATORS APPOINTED IN ACCORDANCE WITH SAID RULES.
+//  
+
+
+#ifndef IMUHRPUBLISHER_H
+#define IMUHRPUBLISHER_H
+
+#include <optional>
+
+#include "packetcallback.h"
+#include "publisherhelperfunctions.h"
+#include <sensor_msgs/msg/imu.hpp>
+
+
+struct ImuHRPublisher : public PacketCallback, PublisherHelperFunctions
+{
+    rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub;
+    double orientation_variance[3];
+    double linear_acceleration_variance[3];
+    double angular_velocity_variance[3];
+    rclcpp::Node::SharedPtr node_handle;
+    // Varaiables to store the last received unpublished value
+    std::optional<geometry_msgs::msg::Vector3> last_accel;
+    std::optional<geometry_msgs::msg::Vector3> last_gyro;
+
+    ImuHRPublisher(rclcpp::Node::SharedPtr node)
+        : node_handle(node)
+    {
+        std::vector<double> variance = {0, 0, 0};
+        node->declare_parameter("orientation_stddev", variance);
+        node->declare_parameter("angular_velocity_stddev", variance);
+        node->declare_parameter("linear_acceleration_stddev", variance);
+
+        int pub_queue_size = 5;
+        node->get_parameter("publisher_queue_size", pub_queue_size);
+        pub = node->create_publisher<sensor_msgs::msg::Imu>("/imu/data", pub_queue_size);
+
+        // REP 145: Conventions for IMU Sensor Drivers (http://www.ros.org/reps/rep-0145.html)
+        variance_from_stddev_param("orientation_stddev", orientation_variance, node);
+        variance_from_stddev_param("angular_velocity_stddev", angular_velocity_variance, node);
+        variance_from_stddev_param("linear_acceleration_stddev", linear_acceleration_variance, node);
+    }
+
+    void operator()(const XsDataPacket &packet, rclcpp::Time timestamp)
+    {
+        bool quaternion_available = packet.containsOrientation();
+        bool gyro_hr_available = packet.containsRateOfTurnHR();
+        bool accel_hr_available = packet.containsAccelerationHR();
+
+        geometry_msgs::msg::Quaternion quaternion;
+        if (quaternion_available)
+        {
+            XsQuaternion q = packet.orientationQuaternion();
+
+            quaternion.w = q.w();
+            quaternion.x = q.x();
+            quaternion.y = q.y();
+            quaternion.z = q.z();
+        }
+
+        geometry_msgs::msg::Vector3 gyro;
+        if (gyro_hr_available)
+        {
+            XsVector g = packet.rateOfTurnHR();
+            gyro.x = g[0];
+            gyro.y = g[1];
+            gyro.z = g[2];
+            last_gyro = gyro;
+        }
+
+        geometry_msgs::msg::Vector3 accel;
+        if (accel_hr_available)
+        {
+            XsVector a = packet.accelerationHR();
+            accel.x = a[0];
+            accel.y = a[1];
+            accel.z = a[2];
+            last_accel = accel;
+        }
+
+        // Imu message, publish if any of the fields is available
+        if (last_accel.has_value() && last_gyro.has_value())
+        {
+            sensor_msgs::msg::Imu msg;
+
+            std::string frame_id = DEFAULT_FRAME_ID;
+            node_handle->get_parameter("frame_id", frame_id);
+
+            msg.header.stamp = timestamp;
+            msg.header.frame_id = frame_id;
+
+            msg.orientation = quaternion;
+            if (quaternion_available)
+            {
+                msg.orientation_covariance[0] = orientation_variance[0];
+                msg.orientation_covariance[4] = orientation_variance[1];
+                msg.orientation_covariance[8] = orientation_variance[2];
+            }
+            else
+            {
+                msg.orientation_covariance[0] = -1; // mark as not available
+            }
+
+            msg.angular_velocity = *last_gyro;
+            if (gyro_hr_available)
+            {
+                msg.angular_velocity_covariance[0] = angular_velocity_variance[0];
+                msg.angular_velocity_covariance[4] = angular_velocity_variance[1];
+                msg.angular_velocity_covariance[8] = angular_velocity_variance[2];
+            }
+            else
+            {
+                msg.angular_velocity_covariance[0] = -1; // mark as not available
+            }
+
+            msg.linear_acceleration = *last_accel;
+            if (accel_hr_available)
+            {
+                msg.linear_acceleration_covariance[0] = linear_acceleration_variance[0];
+                msg.linear_acceleration_covariance[4] = linear_acceleration_variance[1];
+                msg.linear_acceleration_covariance[8] = linear_acceleration_variance[2];
+            }
+            else
+            {
+                msg.linear_acceleration_covariance[0] = -1; // mark as not available
+            }
+
+            pub->publish(msg);
+            
+            // Removing published values
+            last_accel.reset();
+            last_gyro.reset();
+        }
+    }
+};
+
+#endif

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/imuhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/imuhrpublisher.h
@@ -61,7 +61,9 @@ struct ImuHRPublisher : public PacketCallback, PublisherHelperFunctions
 
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<sensor_msgs::msg::Imu>("/imu/data", pub_queue_size);
+        rclcpp::QoS qos = rclcpp::SensorDataQoS();
+        qos.keep_last(pub_queue_size); 
+        pub = node->create_publisher<sensor_msgs::msg::Imu>("/imu/data", qos);
 
         // REP 145: Conventions for IMU Sensor Drivers (http://www.ros.org/reps/rep-0145.html)
         variance_from_stddev_param("orientation_stddev", orientation_variance, node);

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -45,6 +45,7 @@
 #include "messagepublishers/freeaccelerationpublisher.h"
 #include "messagepublishers/gnsspublisher.h"
 #include "messagepublishers/imupublisher.h"
+#include "messagepublishers/imuhrpublisher.h"
 #include "messagepublishers/magneticfieldpublisher.h"
 #include "messagepublishers/orientationincrementspublisher.h"
 #include "messagepublishers/orientationpublisher.h"
@@ -155,13 +156,24 @@ void XdaInterface::registerPublishers()
 	{
 		registerCallback(new AngularVelocityHRPublisher(m_node));
 	}
+	
 
-	if(isDeviceVruAhrs || isDeviceGnss)
+	if(m_node->get_parameter("pub_imu", should_publish) && should_publish)
 	{
-		if (m_node->get_parameter("pub_imu", should_publish) && should_publish)
+		if(m_node->get_parameter("pub_imu_hr", should_publish) && should_publish)
+		{
+			registerCallback(new ImuHRPublisher(m_node));
+		}
+		else
 		{
 			registerCallback(new ImuPublisher(m_node));
 		}
+
+	}
+	
+
+	if(isDeviceVruAhrs || isDeviceGnss)
+	{
 		if (m_node->get_parameter("pub_quaternion", should_publish) && should_publish)
 		{
 			registerCallback(new OrientationPublisher(m_node));
@@ -1334,6 +1346,7 @@ void XdaInterface::declareCommonParameters()
 	m_node->declare_parameter("pub_utctime", should_publish);
 	m_node->declare_parameter("pub_sampletime", should_publish);
 	m_node->declare_parameter("pub_imu", should_publish);
+	m_node->declare_parameter("pub_imu_hr", should_publish);
 	m_node->declare_parameter("pub_quaternion", should_publish);
 	m_node->declare_parameter("pub_euler", should_publish);
 	m_node->declare_parameter("pub_free_acceleration", should_publish);

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -148,7 +148,7 @@ void XdaInterface::registerPublishers()
 		//RCLCPP_INFO(m_node->get_logger(), "registerCallback UTCTimePublisher....");
 		registerCallback(new UTCTimePublisher(m_node));
 	}
-	if (m_node->get_parameter("pub_accelerationhr", should_publish) && should_publish)
+	if (m_node->get_parameter("pub_acceleration_hr", should_publish) && should_publish)
 	{
 		registerCallback(new AccelerationHRPublisher(m_node));
 	}
@@ -1358,7 +1358,7 @@ void XdaInterface::declareCommonParameters()
 
 	m_node->declare_parameter("pub_temperature", should_publish);
 	m_node->declare_parameter("pub_pressure", should_publish);
-	m_node->declare_parameter("pub_accelerationhr", should_publish);
+	m_node->declare_parameter("pub_acceleration_hr", should_publish);
 	m_node->declare_parameter("pub_angular_velocity_hr", should_publish);
 	m_node->declare_parameter("pub_transform", should_publish);
 	m_node->declare_parameter("pub_status", should_publish);


### PR DESCRIPTION
This PR to the official ROS 2 driver enables `/imu/data` to be able to publish the high rate angular velocity and linear acceleration messages. 

When the parameter `pub_imu_hr` is set to true in the .yaml file (located in the param folder (runtime_nl has a copy with the param we use), then it combines messages from the `/imu/angular_velocity_hr` and `/imu/acceleration_hr` to publish `/imu/data` at a higher rate.

When this is set to false, it publishes the output from the Xsens sensor engine (capped at 100Hz max) to `/imu/data`.
