### PR TITLE
Ros2 driver node manual gyro bias estimate subscriber

### DIFF
--- a/src/xsens_mti_ros2_driver/include/xdainterface.h
+++ b/src/xsens_mti_ros2_driver/include/xdainterface.h
@@ -38,6 +38,7 @@
 #include "xdacallback.h"
 #include <xstypes/xsportinfo.h>
 #include <xstypes/xsstring.h>
+#include "std_msgs/msg/empty.hpp"
 
 #include <chrono>
 
@@ -80,6 +81,7 @@ private:
 	rclcpp::Node::SharedPtr m_node; 
 	// Timer for Manual Gyro Bias Estimation
 	rclcpp::TimerBase::SharedPtr m_manualGyroBiasTimer;
+	rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr m_manualGyroBiasSubscriber;
 	rclcpp::Subscription<mavros_msgs::msg::RTCM>::SharedPtr m_rtcmSubscription;
 };
 

--- a/src/xsens_mti_ros2_driver/include/xdainterface.h
+++ b/src/xsens_mti_ros2_driver/include/xdainterface.h
@@ -70,7 +70,7 @@ private:
 	bool handleError(std::string error);
 	void declareCommonParameters();
 	bool configureSensorSettings();
-	bool manualGyroBiasEstimation(uint16_t duration);
+	bool manualGyroBiasEstimation(uint16_t sleep, uint16_t duration);
 
 	XsControl *m_control;
 	XsDevice *m_device;

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -468,7 +468,7 @@ bool XdaInterface::manualGyroBiasEstimation(uint16_t duration)
 	snd.setDataShort(duration);
 	if (!m_device->sendCustomMessage(snd, true, rcv, 1000))
 		return false;
-
+    RCLCPP_INFO(m_node->get_logger(), "MGBE done.");
 	return true;
 }
 

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -470,7 +470,6 @@ bool XdaInterface::manualGyroBiasEstimation(uint16_t sleep, uint16_t duration)
 	snd.setDataShort(duration);
 	if (!m_device->sendCustomMessage(snd, true, rcv, 1000))
 		return false;
-    RCLCPP_INFO(m_node->get_logger(), "MGBE done.");
 	return true;
 }
 

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -224,7 +224,8 @@ void XdaInterface::registerPublishers()
 	if(isDeviceGnssRtk)
 	{
 		m_rtcmSubscription = m_node->create_subscription<mavros_msgs::msg::RTCM>(
-			"/rtcm", 100,
+			"/rtcm",
+			100,
 			std::bind(&XdaInterface::rtcmCallback, this, std::placeholders::_1)
 		);
 		RCLCPP_INFO(m_node->get_logger(), "Subscribing to /rtcm rostopic");
@@ -470,6 +471,7 @@ bool XdaInterface::manualGyroBiasEstimation(uint16_t sleep, uint16_t duration)
 	snd.setDataShort(duration);
 	if (!m_device->sendCustomMessage(snd, true, rcv, 1000))
 		return false;
+
 	return true;
 }
 

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -501,7 +501,7 @@ void XdaInterface::setupManualGyroBiasEstimation()
 				int event_interval = manual_gyro_bias_param[0];
 				int duration = manual_gyro_bias_param[1];
 
-				if (event_interval < 10)
+				if (event_interval > 0 && event_interval < 10)
 				{
 					RCLCPP_INFO(m_node->get_logger(), "Event interval is less than 10 seconds, setting it to 10 seconds.");
 					event_interval = 10;
@@ -513,10 +513,12 @@ void XdaInterface::setupManualGyroBiasEstimation()
 				}
 
 				// Start the timer for MGBE with the retrieved parameters
-				m_manualGyroBiasTimer = m_node->create_wall_timer(
-					std::chrono::seconds(event_interval),
-					[this, duration]() { this->manualGyroBiasEstimation(duration); }
-				);
+				if (event_interval > 0) {
+                    m_manualGyroBiasTimer = m_node->create_wall_timer(
+                        std::chrono::seconds(event_interval),
+                        [this, duration]() { this->manualGyroBiasEstimation(duration); }
+                    );
+                }
 
 				// Start the subscriber for MGBE with the retrieved parameters
 				m_manualGyroBiasSubscriber = m_node->create_subscription<std_msgs::msg::Empty>(


### PR DESCRIPTION
Add a subscriber to the Ros2 driver node. This allows triggering manual gyro bias estimation from outside the driver node.