### PR TITLE
publisher topics respect namespaces

### DIFF
--- a/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationhrpublisher.h
@@ -44,7 +44,7 @@ struct AccelerationHRPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/acceleration_hr", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("imu/acceleration_hr", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationpublisher.h
@@ -44,7 +44,7 @@ struct AccelerationPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/acceleration", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("imu/acceleration", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocityhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocityhrpublisher.h
@@ -44,7 +44,7 @@ struct AngularVelocityHRPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/angular_velocity_hr", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("imu/angular_velocity_hr", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocitypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocitypublisher.h
@@ -44,7 +44,7 @@ struct AngularVelocityPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/angular_velocity", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("imu/angular_velocity", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/freeaccelerationpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/freeaccelerationpublisher.h
@@ -44,7 +44,7 @@ struct FreeAccelerationPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/filter/free_acceleration", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("filter/free_acceleration", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/gnssposepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/gnssposepublisher.h
@@ -47,7 +47,7 @@ struct GNSSPOSEPublisher : public PacketCallback
         node->get_parameter("publisher_queue_size", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
 
-        pub = node->create_publisher<geometry_msgs::msg::PoseStamped>("/gnss_pose", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::PoseStamped>("gnss_pose", pub_queue_size);
 
         
     }

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/gnsspublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/gnsspublisher.h
@@ -49,7 +49,7 @@ struct GnssPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<sensor_msgs::msg::NavSatFix>("/gnss", pub_queue_size);
+        pub = node->create_publisher<sensor_msgs::msg::NavSatFix>("gnss", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/imupublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/imupublisher.h
@@ -57,7 +57,7 @@ struct ImuPublisher : public PacketCallback, PublisherHelperFunctions
 
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<sensor_msgs::msg::Imu>("/imu/data", pub_queue_size);
+        pub = node->create_publisher<sensor_msgs::msg::Imu>("imu/data", pub_queue_size);
 
         // REP 145: Conventions for IMU Sensor Drivers (http://www.ros.org/reps/rep-0145.html)
         variance_from_stddev_param("orientation_stddev", orientation_variance, node);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/magneticfieldpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/magneticfieldpublisher.h
@@ -50,7 +50,7 @@ struct MagneticFieldPublisher : public PacketCallback, PublisherHelperFunctions
 
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<sensor_msgs::msg::MagneticField>("/imu/mag", pub_queue_size);
+        pub = node->create_publisher<sensor_msgs::msg::MagneticField>("imu/mag", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
         variance_from_stddev_param("magnetic_field_stddev", magnetic_field_variance, node);
     }

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/nmeapublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/nmeapublisher.h
@@ -57,7 +57,7 @@ struct NMEAPublisher : public PacketCallback
         node->get_parameter("publisher_queue_size", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
 
-        pub = node->create_publisher<nmea_msgs::msg::Sentence>("/nmea", pub_queue_size);
+        pub = node->create_publisher<nmea_msgs::msg::Sentence>("nmea", pub_queue_size);
 
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/odometrypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/odometrypublisher.h
@@ -69,7 +69,7 @@ struct ODOMETRYPublisher : public PacketCallback
         node->get_parameter("publisher_queue_size", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
 
-        pub = node->create_publisher<nav_msgs::msg::Odometry>("/odometry", pub_queue_size);
+        pub = node->create_publisher<nav_msgs::msg::Odometry>("odometry", pub_queue_size);
 
         m_static_tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
         m_tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/orientationeulerpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/orientationeulerpublisher.h
@@ -44,7 +44,7 @@ struct OrientationEulerPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/filter/euler", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("filter/euler", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/orientationincrementspublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/orientationincrementspublisher.h
@@ -44,7 +44,7 @@ struct OrientationIncrementsPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::QuaternionStamped>("/imu/dq", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::QuaternionStamped>("imu/dq", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/orientationpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/orientationpublisher.h
@@ -44,7 +44,7 @@ struct OrientationPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::QuaternionStamped>("/filter/quaternion", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::QuaternionStamped>("filter/quaternion", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/positionllapublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/positionllapublisher.h
@@ -45,7 +45,7 @@ struct PositionLLAPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/filter/positionlla", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("filter/positionlla", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/pressurepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/pressurepublisher.h
@@ -44,7 +44,7 @@ struct PressurePublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<sensor_msgs::msg::FluidPressure>("/pressure", pub_queue_size);
+        pub = node->create_publisher<sensor_msgs::msg::FluidPressure>("pressure", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/statuspublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/statuspublisher.h
@@ -49,7 +49,7 @@ struct StatusPublisher : public PacketCallback
         node->get_parameter("publisher_queue_size", pub_queue_size);
         //node->get_parameter("frame_id", frame_id);
 
-        pub = node->create_publisher<xsens_mti_ros2_driver::msg::XsStatusWord>("/status", pub_queue_size);
+        pub = node->create_publisher<xsens_mti_ros2_driver::msg::XsStatusWord>("status", pub_queue_size);
     }
 
     void parseToMessage(xsens_mti_ros2_driver::msg::XsStatusWord &msg, uint32_t status)

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/temperaturepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/temperaturepublisher.h
@@ -45,7 +45,7 @@ struct TemperaturePublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<sensor_msgs::msg::Temperature>("/temperature", pub_queue_size);
+        pub = node->create_publisher<sensor_msgs::msg::Temperature>("temperature", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/timereferencepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/timereferencepublisher.h
@@ -44,7 +44,7 @@ struct TimeReferencePublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<sensor_msgs::msg::TimeReference>("/imu/time_ref", pub_queue_size);
+        pub = node->create_publisher<sensor_msgs::msg::TimeReference>("imu/time_ref", pub_queue_size);
     }
 
     void operator()(const XsDataPacket &packet, rclcpp::Time timestamp)

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/twistpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/twistpublisher.h
@@ -45,7 +45,7 @@ struct TwistPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::TwistStamped>("/filter/twist", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::TwistStamped>("filter/twist", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/velocityincrementpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/velocityincrementpublisher.h
@@ -44,7 +44,7 @@ struct VelocityIncrementPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/dv", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("imu/dv", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/velocitypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/velocitypublisher.h
@@ -46,7 +46,7 @@ struct VelocityPublisher : public PacketCallback
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/filter/velocity", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("filter/velocity", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
     }
 


### PR DESCRIPTION
All topics of the message publisher (except "imu/utctime") have absolute topic names (ones starting with "/").  That makes it hard to use several Xsens nodes together as all topics have to be manually renamed to avoid conflicts.  Making the topic names relative (i.e. removing the leading slash "/") allows to just start several nodes in different namespaces to make them work together.

When starting the Xsens node without explicit namespace name, the behavior of the Xsens-node isn't affected by this patch.

Note that subscriber topic "/rtcm" in xdainterface.cpp:XdaInterface::registerPublishers() is still absolute, as I'm not sure what it does and I don't know if several Xsens devices in one system (e.g. robot) would all be supposed to subscribe the same global "/rtcm" or each would subscribe their own "rtcm" (ideally, by default placed in their own namespace).