### PR TITLE
Create LICENSE.txt for NTRIP node for both ROS and ROS2

### DIFF
--- a/src/ntrip/LICENSE.txt
+++ b/src/ntrip/LICENSE.txt
@@ -1,0 +1,6 @@
+LICENSE
+
+TODO: License to be added by the repository owner.
+
+This repository currently has no license. Please select and add
+an appropriate open-source license (e.g., BSD-3-Clause, Apache-2.0).

--- a/src/ntrip/LICENSE.txt
+++ b/src/ntrip/LICENSE.txt
@@ -1,6 +1,3 @@
-LICENSE
+MIT License
 
-TODO: License to be added by the repository owner.
-
-This repository currently has no license. Please select and add
-an appropriate open-source license (e.g., BSD-3-Clause, Apache-2.0).
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
LICENSE

TODO: License to be added by the repository owner.

This repository currently has no license. Please select and add
an appropriate open-source license (e.g., BSD-3-Clause, Apache-2.0).
