### PR TITLE
Add timestamp to status message

### DIFF
--- a/src/xsens_mti_ros2_driver/msg/XsStatusWord.msg
+++ b/src/xsens_mti_ros2_driver/msg/XsStatusWord.msg
@@ -1,4 +1,5 @@
 # Define the custom XsStatusWord message
+std_msgs/Header header
 bool selftest
 bool filter_valid
 bool gnss_fix

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/statuspublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/statuspublisher.h
@@ -40,14 +40,14 @@
 struct StatusPublisher : public PacketCallback
 {
     rclcpp::Publisher<xsens_mti_ros2_driver::msg::XsStatusWord>::SharedPtr pub;
-    //std::string frame_id = DEFAULT_FRAME_ID;
+    std::string frame_id = DEFAULT_FRAME_ID;
 
     StatusPublisher(rclcpp::Node::SharedPtr node)
     {
         int pub_queue_size = 5;
 
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        //node->get_parameter("frame_id", frame_id);
+        node->get_parameter("frame_id", frame_id);
 
         pub = node->create_publisher<xsens_mti_ros2_driver::msg::XsStatusWord>("/status", pub_queue_size);
     }
@@ -122,6 +122,9 @@ struct StatusPublisher : public PacketCallback
         if (packet.containsStatus())
         {
             xsens_mti_ros2_driver::msg::XsStatusWord msg;
+
+            msg.header.stamp = timestamp;
+            msg.header.frame_id = frame_id;
 
             uint32_t status = packet.status();
             parseToMessage(msg, status);


### PR DESCRIPTION
Add timestamp to header message to properly add sync timestamps to sensors that use syncout

<img width="413" height="339" alt="image" src="https://github.com/user-attachments/assets/bd45701c-7a98-4554-8f28-b19bdd10eba7" />
