### PR TITLE
Add body-frame variants of /filter/euler, free_acceleration, velocity

### DIFF
--- a/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
+++ b/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
@@ -134,7 +134,15 @@
         pub_imu: true
         pub_quaternion: true
         pub_euler: true
+        # Body-frame Euler angles (orientation of the world frame as seen
+        # from the sensor; conjugate of the body->world rotation), tagged
+        # with the sensor frame_id. Use when downstream code wants
+        # rotations referred to the sensor body axes.
+        pub_euler_body: false
         pub_free_acceleration: true
+        # Free acceleration rotated from the fixed (ENU/NED) frame into
+        # the sensor body frame, tagged with the sensor frame_id.
+        pub_free_acceleration_body: false
         pub_angular_velocity: true
         pub_acceleration: true
         pub_dq: false
@@ -150,6 +158,10 @@
         pub_gnss: true          # For GNSS/INS Version of MTI only
         pub_positionLLA: true   # For GNSS/INS Version of MTI only
         pub_velocity: true      # For GNSS/INS Version of MTI only
+        # Velocity rotated from the fixed (ENU/NED) frame into the sensor
+        # body frame, tagged with the sensor frame_id. Requires both
+        # velocity and orientation to be present in the data packet.
+        pub_velocity_body: false # For GNSS/INS Version of MTI only
         pub_nmea: true          # For GNSS/INS Version of MTI only
         pub_gnsspose: true      # For GNSS/INS Version of MTI only
         pub_odometry: false     # For GNSS/INS Version of MTI only

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/freeaccelerationbodypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/freeaccelerationbodypublisher.h
@@ -1,0 +1,78 @@
+//  Copyright (c) 2003-2024 Movella Technologies B.V. or subsidiaries worldwide.
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//
+//  1.	Redistributions of source code must retain the above copyright notice,
+//  	this list of conditions, and the following disclaimer.
+//
+//  2.	Redistributions in binary form must reproduce the above copyright notice,
+//  	this list of conditions, and the following disclaimer in the documentation
+//  	and/or other materials provided with the distribution.
+//
+//  3.	Neither the names of the copyright holders nor the names of their contributors
+//  	may be used to endorse or promote products derived from this software without
+//  	specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+//  THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+//  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR
+//  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.THE LAWS OF THE NETHERLANDS
+//  SHALL BE EXCLUSIVELY APPLICABLE AND ANY DISPUTES SHALL BE FINALLY SETTLED UNDER THE RULES
+//  OF ARBITRATION OF THE INTERNATIONAL CHAMBER OF COMMERCE IN THE HAGUE BY ONE OR MORE
+//  ARBITRATORS APPOINTED IN ACCORDANCE WITH SAID RULES.
+
+
+#ifndef FREEACCELERATIONBODYPUBLISHER_H
+#define FREEACCELERATIONBODYPUBLISHER_H
+
+#include "packetcallback.h"
+#include "publisherhelperfunctions.h"
+#include <geometry_msgs/msg/vector3_stamped.hpp>
+
+// The Xsens filter outputs free acceleration in the fixed frame
+// (ENU/NED/NWU). This publisher rotates that vector into the sensor body
+// frame using the orientation quaternion, so the resulting topic is
+// expressed along the IMU's own X/Y/Z axes.
+struct FreeAccelerationBodyPublisher : public PacketCallback
+{
+    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    std::string frame_id = DEFAULT_FRAME_ID;
+
+    FreeAccelerationBodyPublisher(rclcpp::Node::SharedPtr node)
+    {
+        int pub_queue_size = 5;
+        node->get_parameter("publisher_queue_size", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/filter/free_acceleration_body", pub_queue_size);
+        node->get_parameter("frame_id", frame_id);
+    }
+
+    void operator()(const XsDataPacket &packet, rclcpp::Time timestamp)
+    {
+        if (packet.containsFreeAcceleration() && packet.containsOrientation())
+        {
+            XsVector free_accel = packet.freeAcceleration();
+            XsQuaternion q = packet.orientationQuaternion();
+
+            double bx, by, bz;
+            rotateWorldToBody(q, free_accel[0], free_accel[1], free_accel[2], bx, by, bz);
+
+            geometry_msgs::msg::Vector3Stamped msg;
+            msg.header.stamp = timestamp;
+            msg.header.frame_id = frame_id;
+            msg.vector.x = bx;
+            msg.vector.y = by;
+            msg.vector.z = bz;
+
+            pub->publish(msg);
+        }
+    }
+};
+
+#endif

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/orientationeulerbodypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/orientationeulerbodypublisher.h
@@ -1,0 +1,78 @@
+//  Copyright (c) 2003-2024 Movella Technologies B.V. or subsidiaries worldwide.
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//
+//  1.	Redistributions of source code must retain the above copyright notice,
+//  	this list of conditions, and the following disclaimer.
+//
+//  2.	Redistributions in binary form must reproduce the above copyright notice,
+//  	this list of conditions, and the following disclaimer in the documentation
+//  	and/or other materials provided with the distribution.
+//
+//  3.	Neither the names of the copyright holders nor the names of their contributors
+//  	may be used to endorse or promote products derived from this software without
+//  	specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+//  THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+//  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR
+//  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.THE LAWS OF THE NETHERLANDS
+//  SHALL BE EXCLUSIVELY APPLICABLE AND ANY DISPUTES SHALL BE FINALLY SETTLED UNDER THE RULES
+//  OF ARBITRATION OF THE INTERNATIONAL CHAMBER OF COMMERCE IN THE HAGUE BY ONE OR MORE
+//  ARBITRATORS APPOINTED IN ACCORDANCE WITH SAID RULES.
+
+
+#ifndef ORIENTATIONEULERBODYPUBLISHER_H
+#define ORIENTATIONEULERBODYPUBLISHER_H
+
+#include "packetcallback.h"
+#include <geometry_msgs/msg/vector3_stamped.hpp>
+
+// Publishes Euler angles of the world->body rotation (i.e. the conjugate
+// of the orientation quaternion the filter outputs). The standard
+// /filter/euler topic publishes the body->world rotation expressed in the
+// fixed frame; this topic gives the same orientation expressed from the
+// body's point of view, useful for users whose downstream code wants
+// rotations referred to the sensor frame.
+struct OrientationEulerBodyPublisher : public PacketCallback
+{
+    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    std::string frame_id = DEFAULT_FRAME_ID;
+
+    OrientationEulerBodyPublisher(rclcpp::Node::SharedPtr node)
+    {
+        int pub_queue_size = 5;
+        node->get_parameter("publisher_queue_size", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/filter/euler_body", pub_queue_size);
+        node->get_parameter("frame_id", frame_id);
+    }
+
+    void operator()(const XsDataPacket &packet, rclcpp::Time timestamp)
+    {
+        if (packet.containsOrientation())
+        {
+            geometry_msgs::msg::Vector3Stamped msg;
+
+            msg.header.stamp = timestamp;
+            msg.header.frame_id = frame_id;
+
+            XsQuaternion q_body_to_world = packet.orientationQuaternion();
+            XsEuler euler(q_body_to_world.conjugate());
+
+            msg.vector.x = euler.roll();
+            msg.vector.y = euler.pitch();
+            msg.vector.z = euler.yaw();
+
+            pub->publish(msg);
+        }
+    }
+};
+
+#endif

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/publisherhelperfunctions.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/publisherhelperfunctions.h
@@ -35,6 +35,29 @@
 #include <string>
 #include <vector>
 #include <rclcpp/rclcpp.hpp>
+#include <xstypes/xsquaternion.h>
+
+// Rotate a vector from the fixed (world) frame into the sensor body
+// frame using the body->world orientation quaternion.
+// Computes v_body = q^-1 * v_world * q in closed form
+// (v + 2*qv_inv x (qv_inv x v + w*v), where qv_inv = -qv).
+inline void rotateWorldToBody(const XsQuaternion &q,
+                              double wx, double wy, double wz,
+                              double &bx, double &by, double &bz)
+{
+    const double qw = q.w();
+    const double qx = q.x();
+    const double qy = q.y();
+    const double qz = q.z();
+
+    const double tx = 2.0 * (-qy * wz + qz * wy);
+    const double ty = 2.0 * (-qz * wx + qx * wz);
+    const double tz = 2.0 * (-qx * wy + qy * wx);
+
+    bx = wx + qw * tx + (-qy * tz + qz * ty);
+    by = wy + qw * ty + (-qz * tx + qx * tz);
+    bz = wz + qw * tz + (-qx * ty + qy * tx);
+}
 
 class PublisherHelperFunctions
 {

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/velocitybodypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/velocitybodypublisher.h
@@ -1,0 +1,77 @@
+//  Copyright (c) 2003-2024 Movella Technologies B.V. or subsidiaries worldwide.
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//
+//  1.	Redistributions of source code must retain the above copyright notice,
+//  	this list of conditions, and the following disclaimer.
+//
+//  2.	Redistributions in binary form must reproduce the above copyright notice,
+//  	this list of conditions, and the following disclaimer in the documentation
+//  	and/or other materials provided with the distribution.
+//
+//  3.	Neither the names of the copyright holders nor the names of their contributors
+//  	may be used to endorse or promote products derived from this software without
+//  	specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+//  THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+//  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR
+//  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.THE LAWS OF THE NETHERLANDS
+//  SHALL BE EXCLUSIVELY APPLICABLE AND ANY DISPUTES SHALL BE FINALLY SETTLED UNDER THE RULES
+//  OF ARBITRATION OF THE INTERNATIONAL CHAMBER OF COMMERCE IN THE HAGUE BY ONE OR MORE
+//  ARBITRATORS APPOINTED IN ACCORDANCE WITH SAID RULES.
+
+
+#ifndef VELOCITYBODYPUBLISHER_H
+#define VELOCITYBODYPUBLISHER_H
+
+#include "packetcallback.h"
+#include "publisherhelperfunctions.h"
+#include <geometry_msgs/msg/vector3_stamped.hpp>
+
+// The Xsens filter outputs velocity in the fixed frame (ENU/NED).
+// This publisher rotates that velocity into the sensor body frame so the
+// resulting topic is the IMU's own forward/lateral/vertical velocity.
+struct VelocityBodyPublisher : public PacketCallback
+{
+    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    std::string frame_id = DEFAULT_FRAME_ID;
+
+    VelocityBodyPublisher(rclcpp::Node::SharedPtr node)
+    {
+        int pub_queue_size = 5;
+        node->get_parameter("publisher_queue_size", pub_queue_size);
+        pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/filter/velocity_body", pub_queue_size);
+        node->get_parameter("frame_id", frame_id);
+    }
+
+    void operator()(const XsDataPacket &packet, rclcpp::Time timestamp)
+    {
+        if (packet.containsVelocity() && packet.containsOrientation())
+        {
+            XsVector v = packet.velocity();
+            XsQuaternion q = packet.orientationQuaternion();
+
+            double bx, by, bz;
+            rotateWorldToBody(q, v[0], v[1], v[2], bx, by, bz);
+
+            geometry_msgs::msg::Vector3Stamped msg;
+            msg.header.stamp = timestamp;
+            msg.header.frame_id = frame_id;
+            msg.vector.x = bx;
+            msg.vector.y = by;
+            msg.vector.z = bz;
+
+            pub->publish(msg);
+        }
+    }
+};
+
+#endif

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -45,6 +45,7 @@
 #include "messagepublishers/accelerationpublisher.h"
 #include "messagepublishers/angularvelocitypublisher.h"
 #include "messagepublishers/freeaccelerationpublisher.h"
+#include "messagepublishers/freeaccelerationbodypublisher.h"
 #include "messagepublishers/gnsspublisher.h"
 #include "messagepublishers/gnsspvtpublisher.h"
 #include "messagepublishers/gnssatinfopublisher.h"
@@ -53,6 +54,7 @@
 #include "messagepublishers/orientationincrementspublisher.h"
 #include "messagepublishers/orientationpublisher.h"
 #include "messagepublishers/orientationeulerpublisher.h"
+#include "messagepublishers/orientationeulerbodypublisher.h"
 #include "messagepublishers/pressurepublisher.h"
 #include "messagepublishers/temperaturepublisher.h"
 #include "messagepublishers/timereferencepublisher.h"
@@ -61,6 +63,7 @@
 #include "messagepublishers/velocityincrementpublisher.h"
 #include "messagepublishers/positionllapublisher.h"
 #include "messagepublishers/velocitypublisher.h"
+#include "messagepublishers/velocitybodypublisher.h"
 #include "messagepublishers/statuspublisher.h"
 #include "messagepublishers/nmeapublisher.h"
 #include "messagepublishers/gnssposepublisher.h"
@@ -178,9 +181,17 @@ void XdaInterface::registerPublishers()
 		{
 			registerCallback(new OrientationEulerPublisher(m_node));
 		}
+		if (m_node->get_parameter("pub_euler_body", should_publish) && should_publish)
+		{
+			registerCallback(new OrientationEulerBodyPublisher(m_node));
+		}
 		if (m_node->get_parameter("pub_free_acceleration", should_publish) && should_publish)
 		{
 			registerCallback(new FreeAccelerationPublisher(m_node));
+		}
+		if (m_node->get_parameter("pub_free_acceleration_body", should_publish) && should_publish)
+		{
+			registerCallback(new FreeAccelerationBodyPublisher(m_node));
 		}
 		if (m_node->get_parameter("pub_transform", should_publish) && should_publish)
 		{
@@ -211,6 +222,10 @@ void XdaInterface::registerPublishers()
 		if (m_node->get_parameter("pub_velocity", should_publish) && should_publish)
 		{
 			registerCallback(new VelocityPublisher(m_node));
+		}
+		if (m_node->get_parameter("pub_velocity_body", should_publish) && should_publish)
+		{
+			registerCallback(new VelocityBodyPublisher(m_node));
 		}
 		if (m_node->get_parameter("pub_twist", should_publish) && should_publish)
 		{
@@ -1516,8 +1531,12 @@ void XdaInterface::declareCommonParameters()
 		m_node->declare_parameter("pub_quaternion", should_publish);
 	if (!m_node->has_parameter("pub_euler"))
 		m_node->declare_parameter("pub_euler", should_publish);
+	if (!m_node->has_parameter("pub_euler_body"))
+		m_node->declare_parameter("pub_euler_body", false);
 	if (!m_node->has_parameter("pub_free_acceleration"))
 		m_node->declare_parameter("pub_free_acceleration", should_publish);
+	if (!m_node->has_parameter("pub_free_acceleration_body"))
+		m_node->declare_parameter("pub_free_acceleration_body", false);
 	if (!m_node->has_parameter("pub_angular_velocity"))
 		m_node->declare_parameter("pub_angular_velocity", should_publish);
 	if (!m_node->has_parameter("pub_acceleration"))
@@ -1548,6 +1567,8 @@ void XdaInterface::declareCommonParameters()
 		m_node->declare_parameter("pub_positionLLA", should_publish);
 	if (!m_node->has_parameter("pub_velocity"))
 		m_node->declare_parameter("pub_velocity", should_publish);
+	if (!m_node->has_parameter("pub_velocity_body"))
+		m_node->declare_parameter("pub_velocity_body", false);
 	if (!m_node->has_parameter("pub_nmea"))
 		m_node->declare_parameter("pub_nmea", should_publish);
 	if (!m_node->has_parameter("pub_gnsspose"))


### PR DESCRIPTION
## Summary

The Xsens filter outputs `/filter/euler`, `/filter/free_acceleration` and `/filter/velocity` in a local fixed frame (ENU/NED) — see #33 / #46 for context. This PR adds three opt-in companion topics that publish the same quantities expressed in the sensor body frame, tagged with the sensor `frame_id` so they align with `/imu/data` and the TF tree.

| New topic | Source | Transform applied |
|---|---|---|
| `/filter/euler_body` | `orientationQuaternion()` | Euler decomposition of `q.conjugate()` (rotation from world into body) |
| `/filter/free_acceleration_body` | `freeAcceleration()` + `orientationQuaternion()` | `q⁻¹ * v_world * q` |
| `/filter/velocity_body` | `velocity()` + `orientationQuaternion()` | `q⁻¹ * v_world * q` |

Both vector publishers gate on the packet containing **both** the data and the orientation, so the rotation is always well-defined.

## Changes

- `messagepublishers/orientationeulerbodypublisher.h` — new publisher for `/filter/euler_body`.
- `messagepublishers/freeaccelerationbodypublisher.h` — new publisher for `/filter/free_acceleration_body`.
- `messagepublishers/velocitybodypublisher.h` — new publisher for `/filter/velocity_body`.
- `messagepublishers/publisherhelperfunctions.h` — adds inline `rotateWorldToBody(q, vx, vy, vz, ...)` closed-form helper (no extra Xsens linalg deps).
- `xdainterface.cpp` — includes, registers each publisher behind its parameter, and declares `pub_euler_body`, `pub_free_acceleration_body`, `pub_velocity_body` (default `false`).
- `param/xsens_mti_node.yaml` — documents the three new flags next to their fixed-frame counterparts.

The new flags default to `false`, so existing setups are unchanged.

## Test plan

- [x] `colcon build --packages-select xsens_mti_ros2_driver` succeeds on Humble.
- [x] `colcon test --packages-select xsens_mti_ros2_driver` — existing 9 unit tests still pass (no regressions in `imupublisher`/`gnsspvtpublisher`).
- [x] Sanity check of the rotation math: 90° yaw quaternion takes body `(1,0,0)` → world `(0,1,0)` and inverse takes world `(0,1,0)` → body `(1,0,0)`; round-trip identity holds.
- [ ] On real MTi-680(G) hardware: with `pub_velocity: true` and `pub_velocity_body: true`, drive a known straight-line trajectory and confirm `/filter/velocity_body.x` matches the IMU's forward axis while `/filter/velocity` reflects ENU/NED.
- [ ] Confirm `/filter/euler_body` `frame_id` is `imu_link` (or whatever `frame_id` is set to) and that all three new topics share the same stamp as their fixed-frame counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)