### PR TITLE
Add pub_odometry_transform to gate odometry TF broadcasting

### DIFF
--- a/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
+++ b/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
@@ -153,6 +153,7 @@
         pub_nmea: true          # For GNSS/INS Version of MTI only
         pub_gnsspose: true      # For GNSS/INS Version of MTI only
         pub_odometry: false     # For GNSS/INS Version of MTI only
+        pub_odometry_transform: true  # Broadcast odom_init->frame_id (static) and frame_id->base_link (dynamic) TFs from /odometry; requires pub_odometry: true
         pub_gnsspvt: true       # For GNSS/INS Version of MTI only (MTi-7/8/670G/680G/G-710); fixed 4 Hz output rate
         pub_gnssatinfo: true    # For GNSS/INS Version of MTI only (MTi-7/8/670G/680G/G-710); satellite info
         pub_euler_stddev: false # For Sirius and Avior AHRS/VRU only, this is for setouput config, and value will be published at /imu/data topic.

--- a/src/xsens_mti_ros2_driver/param/xsens_mti_node_mti320.yaml
+++ b/src/xsens_mti_ros2_driver/param/xsens_mti_node_mti320.yaml
@@ -153,6 +153,7 @@
         pub_nmea: false          # For GNSS/INS Version of MTI only
         pub_gnsspose: false      # For GNSS/INS Version of MTI only
         pub_odometry: false      # For GNSS/INS Version of MTI only
+        pub_odometry_transform: true  # Broadcast odom_init->frame_id (static) and frame_id->base_link (dynamic) TFs from /odometry; requires pub_odometry: true
         pub_euler_stddev: false  # For Sirius and Avior AHRS/VRU only, this is for setouput config, and value will be published at /imu/data topic.
         pub_ship_motion: false   # For Sirius and Avior AHRS/VRU Only
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/odometrypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/odometrypublisher.h
@@ -65,6 +65,8 @@ struct ODOMETRYPublisher : public PacketCallback
     std::shared_ptr<tf2_ros::StaticTransformBroadcaster> m_static_tf_broadcaster_;
     std::shared_ptr<tf2_ros::TransformBroadcaster> m_tf_broadcaster_;
 
+    bool m_pub_tf = true;
+
     double m_latitude = 0.0;
     double m_longitude = 0.0;
 
@@ -74,11 +76,15 @@ struct ODOMETRYPublisher : public PacketCallback
 
         node->get_parameter("publisher_queue_size", pub_queue_size);
         node->get_parameter("frame_id", frame_id);
+        node->get_parameter("pub_odometry_transform", m_pub_tf);
 
         pub = node->create_publisher<nav_msgs::msg::Odometry>("/odometry", pub_queue_size);
 
-        m_static_tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*node);
-        m_tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
+        if (m_pub_tf)
+        {
+            m_static_tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*node);
+            m_tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
+        }
     }
 
     /**
@@ -353,9 +359,12 @@ struct ODOMETRYPublisher : public PacketCallback
                 pose.orientation.y = 0.0;
                 pose.orientation.z = 0.0;
 
-                geometry_msgs::msg::TransformStamped transform;
-                fillTransform(odom_init_frame_id, frame_id, pose, transform, timestamp);
-                m_static_tf_broadcaster_->sendTransform(transform);
+                if (m_pub_tf)
+                {
+                    geometry_msgs::msg::TransformStamped transform;
+                    fillTransform(odom_init_frame_id, frame_id, pose, transform, timestamp);
+                    m_static_tf_broadcaster_->sendTransform(transform);
+                }
             }
 
             // Compute position relative to initial position
@@ -384,13 +393,16 @@ struct ODOMETRYPublisher : public PacketCallback
             pub->publish(msg);
 
             // Publish odometry transformation
-            geometry_msgs::msg::Pose pose;
-            pose.position = msg.pose.pose.position;
-            pose.orientation = msg.pose.pose.orientation;
+            if (m_pub_tf)
+            {
+                geometry_msgs::msg::Pose pose;
+                pose.position = msg.pose.pose.position;
+                pose.orientation = msg.pose.pose.orientation;
 
-            geometry_msgs::msg::TransformStamped transform;
-            fillTransform(msg.header.frame_id, msg.child_frame_id, pose, transform, timestamp);
-            m_tf_broadcaster_->sendTransform(transform);
+                geometry_msgs::msg::TransformStamped transform;
+                fillTransform(msg.header.frame_id, msg.child_frame_id, pose, transform, timestamp);
+                m_tf_broadcaster_->sendTransform(transform);
+            }
         }
     }
 };

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -1554,6 +1554,8 @@ void XdaInterface::declareCommonParameters()
 		m_node->declare_parameter("pub_gnsspose", should_publish);
 	if (!m_node->has_parameter("pub_odometry"))
 		m_node->declare_parameter("pub_odometry", should_publish);
+	if (!m_node->has_parameter("pub_odometry_transform"))
+		m_node->declare_parameter("pub_odometry_transform", should_publish);
 	if (!m_node->has_parameter("pub_gnsspvt"))
 		m_node->declare_parameter("pub_gnsspvt", should_publish);
 	if (!m_node->has_parameter("pub_gnssatinfo"))


### PR DESCRIPTION
## Summary

- `OdometryPublisher` previously broadcast both a static `odom_init` -> `frame_id` and a dynamic `frame_id` -> `base_link` TF whenever `pub_odometry` was true, with no way to disable the TFs while keeping the `/odometry` topic.
- This conflicted with `pub_transform`, which only gates the `world` -> `frame_id` TF from `TransformPublisher`, so users hit unexpected `imu_link` -> `base_link` links in the TF tree even with `pub_transform: false`.
- Introduces `pub_odometry_transform` (default `true`, preserves current behavior). When set to `false`, neither the static nor the dynamic odometry TF is broadcast, and the broadcasters themselves are not instantiated.

## Changes

- `xdainterface.cpp`: declare `pub_odometry_transform` alongside the other publish flags.
- `param/xsens_mti_node.yaml`, `param/xsens_mti_node_mti320.yaml`: expose the new parameter with an explanatory comment.
- `messagepublishers/odometrypublisher.h`: read the parameter in the constructor, only create the TF broadcasters when enabled, and gate both `sendTransform` calls.

## Test plan

- [ ] Build with `colcon build --packages-select xsens_mti_ros2_driver`.
- [ ] Run with default params (`pub_odometry: true`, `pub_odometry_transform: true`) and verify `odom_init` -> `imu_link` and `imu_link` -> `base_link` TFs are still broadcast (`ros2 run tf2_tools view_frames`).
- [ ] Run with `pub_odometry: true`, `pub_odometry_transform: false` and verify `/odometry` is still published while neither odometry TF appears in `view_frames`.
- [ ] Run with `pub_odometry: false` and verify behavior is unchanged.