### PR TITLE
fix: increase XdaCallback buffer size to prevent data loss at high rate

### DIFF
--- a/src/xsens_mti_ros2_driver/include/xdacallback.h
+++ b/src/xsens_mti_ros2_driver/include/xdacallback.h
@@ -49,7 +49,7 @@ typedef std::pair<rclcpp::Time, XsDataPacket> RosXsDataPacket;
 class XdaCallback : public XsCallback
 {
 public:
-	XdaCallback(rclcpp::Node::SharedPtr node, size_t maxBufferSize = 5);
+	XdaCallback(rclcpp::Node::SharedPtr node, size_t maxBufferSize = 32);
 	virtual ~XdaCallback() throw();
 
 	RosXsDataPacket next(const std::chrono::milliseconds &timeout);


### PR DESCRIPTION
Default buffer size of 5 is smaller than the worst-case burst of frames caused by the FTDI latency_timer default of 16ms, causing oldest frames to be silently dropped. Increase default to 32.

**Test result**
<img width="662" height="180" alt="image" src="https://github.com/user-attachments/assets/34646513-3076-49d9-8a30-bc30298d0c66" />

**Related issue**
https://github.com/xsenssupport/Xsens_MTi_ROS_Driver_and_Ntrip_Client/issues/53

