### PR TITLE
Add lifecycle support and diagnostics publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Here are the recommended Output Configurations and Device Settings:
     - +Manual Gyro Bias Estimation Periodically
     - +Add ``filter/euler`` and high rate topics for ``imu/acceleration_hr``, ``imu/angular_velocity_hr``
     - +Add error messages.
+    - +Lifecycle node support (configure/activate/deactivate/cleanup) with an ``autostart`` parameter.
+    - +Diagnostics publishing on ``/diagnostics``.
 
 - change:
     - ``lib/xspublic/xscontroller/iointerface.h``, line 138, change to ``PO_OneStopBIt`` for PO_XsensDefaults.
@@ -105,42 +107,81 @@ ros2 launch ntrip ntrip_launch.py
 
 ## Lifecycle and Diagnostics
 
-The node is a managed (lifecycle) node. By default `autostart` is true, so it
-configures and activates itself on startup and behaves exactly as before.
+### Lifecycle
 
-To drive it yourself, start it with `autostart:=false` and use the lifecycle
-services:
+The driver is a managed (lifecycle) node, so the MTi can be brought up, paused and
+released on demand instead of only at process start and exit.
+
+By default nothing changes for existing users: the `autostart` parameter is `true`,
+so the node configures and activates itself on startup and streams data exactly as
+it always has.
+
+Set `autostart` to `false` to drive the transitions yourself:
+
 ```
 ros2 run xsens_mti_ros2_driver xsens_mti_node --ros-args -p autostart:=false
-ros2 lifecycle set /xsens_driver configure
-ros2 lifecycle set /xsens_driver activate
+
+ros2 lifecycle get /xsens_driver             # unconfigured [1]
+ros2 lifecycle set /xsens_driver configure   # -> inactive [2]
+ros2 lifecycle set /xsens_driver activate    # -> active [3]
 ```
 
-| transition | effect on the device |
-| ---------- | -------------------- |
-| configure | opens the port, creates the publishers, writes the device configuration |
-| activate | puts the device into measurement mode and starts publishing |
-| deactivate | puts the device back into config mode, stops publishing |
-| cleanup | closes the port and destroys the publishers |
+Note the node is called `xsens_driver` when started with `ros2 run`, and
+`xsens_mti_node` when started from `xsens_mti_node.launch.py`.
 
-While the node is inactive the device is not measuring and no messages are
-published, so `deactivate` is a clean way to pause the sensor without
-restarting the node.
+| transition | what happens on the device |
+| ---------- | -------------------------- |
+| configure | opens the serial port, reads the device information, creates the publishers and applies the device configuration |
+| activate | puts the device into measurement mode, starts logging and periodic gyro bias estimation when enabled, and starts publishing |
+| deactivate | stops recording and puts the device back into config mode, publishing stops |
+| cleanup | closes the serial port and destroys the publishers, so the port becomes available to other processes |
+| shutdown | leaves measurement mode and releases everything |
 
-The node publishes `diagnostic_msgs/DiagnosticArray` on `/diagnostics` while it
-is active, with three statuses:
+Every message publisher is a lifecycle publisher, so no messages are put on the
+wire while the node is inactive. Because the device is taken out of measurement
+mode as well, `deactivate` is a clean way to pause the sensor, and `cleanup`
+releases the serial port, both without restarting the process. Configuring again
+re-opens the port and starts over.
 
-* **Device** - connection state, product code, device ID, firmware version, port
-  and baudrate, plus a count of the errors reported by the device.
-* **Data stream** - packets received, measured rate and the time since the last
-  packet. Warns when the rate drops below `diagnostics_min_rate` and reports the
-  stream as stale after `diagnostics_stale_timeout` seconds without data.
-* **Filter status** - the MTi status word decoded into orientation validity,
-  GNSS fix, RTK status, clipping flags, no-rotation-update state and filter mode.
+### Diagnostics
 
-Diagnostics are configured with `diagnostics_enabled`, `diagnostics_period`,
-`diagnostics_min_rate` and `diagnostics_stale_timeout` in
-`param/xsens_mti_node.yaml`.
+While the node is active it publishes `diagnostic_msgs/DiagnosticArray` on
+`/diagnostics`, the standard topic that `rqt_robot_monitor` and the
+`diagnostic_aggregator` read:
+
+```
+ros2 topic echo /diagnostics
+```
+
+Three statuses are reported:
+
+| status | contents | level |
+| ------ | -------- | ----- |
+| Device | product code, device ID, firmware version, port, baudrate and the number of errors reported by the device | ERROR when no device is connected, WARN when the device reported an error since the last report |
+| Data stream | packets received, the measured rate in Hz and the time since the last packet | ERROR when measuring without any data, STALE after `diagnostics_stale_timeout` seconds without a packet, WARN when the rate is below `diagnostics_min_rate` |
+| Filter status | the MTi status word decoded into orientation validity, GNSS fix, RTK status, clipping flags, no-rotation-update state, filter mode and clock sync | WARN when the orientation is not valid or the sensor data is clipping |
+
+The Data stream status is the quickest way to see that the MTi is still streaming
+at the rate you configured. For example, on an MTi-680G running at 400 Hz:
+
+```
+  name: 'xsens_driver: Data stream'
+  message: Streaming at 401.8 Hz
+  values:
+  - key: Packets received
+    value: '19394'
+  - key: Rate (Hz)
+    value: '401.8'
+```
+
+Diagnostics are configured in `param/xsens_mti_node.yaml`:
+
+| parameter | default | meaning |
+| --------- | ------- | ------- |
+| `diagnostics_enabled` | `true` | publish diagnostics at all |
+| `diagnostics_period` | `1.0` | publishing period in seconds |
+| `diagnostics_min_rate` | `0.0` | warn when the measured packet rate drops below this value in Hz, `0.0` disables the check. Pick a value somewhat below your `output_data_rate` |
+| `diagnostics_stale_timeout` | `1.0` | report the stream as stale after this many seconds without a packet |
 
 ## How to confirm your RTK Status
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,45 @@ and then open another terminal
 ros2 launch ntrip ntrip_launch.py
 ```
 
+## Lifecycle and Diagnostics
+
+The node is a managed (lifecycle) node. By default `autostart` is true, so it
+configures and activates itself on startup and behaves exactly as before.
+
+To drive it yourself, start it with `autostart:=false` and use the lifecycle
+services:
+```
+ros2 run xsens_mti_ros2_driver xsens_mti_node --ros-args -p autostart:=false
+ros2 lifecycle set /xsens_driver configure
+ros2 lifecycle set /xsens_driver activate
+```
+
+| transition | effect on the device |
+| ---------- | -------------------- |
+| configure | opens the port, creates the publishers, writes the device configuration |
+| activate | puts the device into measurement mode and starts publishing |
+| deactivate | puts the device back into config mode, stops publishing |
+| cleanup | closes the port and destroys the publishers |
+
+While the node is inactive the device is not measuring and no messages are
+published, so `deactivate` is a clean way to pause the sensor without
+restarting the node.
+
+The node publishes `diagnostic_msgs/DiagnosticArray` on `/diagnostics` while it
+is active, with three statuses:
+
+* **Device** - connection state, product code, device ID, firmware version, port
+  and baudrate, plus a count of the errors reported by the device.
+* **Data stream** - packets received, measured rate and the time since the last
+  packet. Warns when the rate drops below `diagnostics_min_rate` and reports the
+  stream as stale after `diagnostics_stale_timeout` seconds without data.
+* **Filter status** - the MTi status word decoded into orientation validity,
+  GNSS fix, RTK status, clipping flags, no-rotation-update state and filter mode.
+
+Diagnostics are configured with `diagnostics_enabled`, `diagnostics_period`,
+`diagnostics_min_rate` and `diagnostics_stale_timeout` in
+`param/xsens_mti_node.yaml`.
+
 ## How to confirm your RTK Status
 
 you could check ``ros2 topic echo /rtcm``, there should be HEX RTCM data coming,
@@ -135,6 +174,7 @@ or ``ros2 topic echo /status`` to check the RTK Fix type, it should be 1(RTK Flo
 | status                   | xsens_mti_driver/XsStatusWord | statusWord, 32bit                                                                                                                             | depending on packet                                                             |
 | temperature              | sensor_msgs/Temperature         | temperature from device                                                                                                                       | 1-400Hz(MTi-600 and MTi-100 series), 1-100Hz(MTi-1 series)                      |
 | tf                       | geometry_msgs/TransformStamped  | transformed orientation                                                                                                                       | 1-400Hz(MTi-600 and MTi-100 series), 1-100Hz(MTi-1 series)                      |
+| diagnostics              | diagnostic_msgs/DiagnosticArray | device connection, data stream health and decoded status word                                                                                 | diagnostics_period (default 1Hz)                                                |
 | imu/acceleration_hr         | geometry_msgs/Vector3Stamped    | high rate acceleration                                                                                                                       | see xsens_mti_node.yaml                      |
 | imu/angular_velocity_hr     | geometry_msgs/Vector3Stamped    | high rate angular velocity                                                                                                                   | see xsens_mti_node.yaml                      |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,6 +42,8 @@ git clone --branch ros2 https://github.com/xsenssupport/Xsens_MTi_ROS_Driver_and
     - 周期性地估计陀螺仪偏差(Manual Gyro Bias Estimation)；
     - 添加 ``filter/euler`` 和HR高速率话题，如 ``imu/acceleration_hr``、``imu/angular_velocity_hr``；
     - 添加报错信息。
+    - 支持生命周期节点（configure/activate/deactivate/cleanup），并提供 ``autostart`` 参数；
+    - 在 ``/diagnostics`` 话题上发布诊断信息。
 
 - 修改了以下代码：
     - ``lib/xspublic/xscontroller/iointerface.h``，第 138 行，将 `PO_XsensDefaults` 改为 ``PO_OneStopBit``；
@@ -105,6 +107,80 @@ ros2 launch xsens_mti_ros2_driver display.launch.py
 ros2 launch ntrip ntrip_launch.py
 ```
 
+## 生命周期与诊断信息
+
+### 生命周期（Lifecycle）
+
+本驱动是一个受管理的生命周期节点（managed/lifecycle node），因此可以按需启动、暂停和释放
+MTi 设备，而不再只能在进程启动和退出时进行。
+
+默认行为与以往完全一致：参数 `autostart` 默认为 `true`，节点在启动时会自动完成配置并激活，
+像以前一样直接输出数据。
+
+若要自行控制状态切换，请将 `autostart` 设为 `false`：
+
+```
+ros2 run xsens_mti_ros2_driver xsens_mti_node --ros-args -p autostart:=false
+
+ros2 lifecycle get /xsens_driver             # unconfigured [1]
+ros2 lifecycle set /xsens_driver configure   # -> inactive [2]
+ros2 lifecycle set /xsens_driver activate    # -> active [3]
+```
+
+请注意：使用 `ros2 run` 启动时节点名为 `xsens_driver`，而通过
+`xsens_mti_node.launch.py` 启动时节点名为 `xsens_mti_node`。
+
+| 状态切换 | 对设备的操作 |
+| -------- | ------------ |
+| configure | 打开串口，读取设备信息，创建各个话题发布者，并写入设备配置 |
+| activate | 让设备进入测量模式（measurement mode），按需启动录制与周期性陀螺仪零偏估计（MGBE），并开始发布数据 |
+| deactivate | 停止录制并让设备回到配置模式（config mode），停止发布数据 |
+| cleanup | 关闭串口并销毁发布者，串口随之释放给其他程序使用 |
+| shutdown | 退出测量模式并释放全部资源 |
+
+所有消息发布者都是生命周期发布者（lifecycle publisher），因此在节点未激活时不会有任何消息
+发送到网络上。同时设备也会退出测量模式，所以 `deactivate` 可以干净地暂停传感器，`cleanup`
+可以释放串口，两者都无需重启进程。再次执行 `configure` 会重新打开串口并从头开始。
+
+### 诊断信息（Diagnostics）
+
+节点处于激活状态时，会在 `/diagnostics` 话题上发布 `diagnostic_msgs/DiagnosticArray`，这是
+`rqt_robot_monitor` 和 `diagnostic_aggregator` 所读取的标准话题：
+
+```
+ros2 topic echo /diagnostics
+```
+
+共发布三条状态信息：
+
+| 状态 | 内容 | 报警级别 |
+| ---- | ---- | -------- |
+| Device | 产品型号、设备 ID、固件版本、串口、波特率，以及设备报告的错误次数 | 未连接设备时为 ERROR；自上次发布以来设备报告过错误时为 WARN |
+| Data stream | 已接收的数据包数量、实测频率（Hz）以及距离上一个数据包的时间 | 处于测量模式却收不到数据时为 ERROR；超过 `diagnostics_stale_timeout` 秒没有数据时为 STALE；频率低于 `diagnostics_min_rate` 时为 WARN |
+| Filter status | 将 MTi 状态字（status word）解析为姿态是否有效、GNSS 定位、RTK 状态、削波（clipping）标志、无旋转更新状态、滤波模式和时钟同步等 | 姿态无效或传感器数据出现削波时为 WARN |
+
+其中 Data stream 是确认 MTi 是否仍按设定频率输出数据最快捷的方式。例如 MTi-680G 以 400 Hz
+运行时：
+
+```
+  name: 'xsens_driver: Data stream'
+  message: Streaming at 401.8 Hz
+  values:
+  - key: Packets received
+    value: '19394'
+  - key: Rate (Hz)
+    value: '401.8'
+```
+
+诊断相关参数在 `param/xsens_mti_node.yaml` 中配置：
+
+| 参数 | 默认值 | 含义 |
+| ---- | ------ | ---- |
+| `diagnostics_enabled` | `true` | 是否发布诊断信息 |
+| `diagnostics_period` | `1.0` | 发布周期，单位为秒 |
+| `diagnostics_min_rate` | `0.0` | 实测数据包频率低于该值（Hz）时报 WARN，设为 `0.0` 则不检查。建议取略低于 `output_data_rate` 的值 |
+| `diagnostics_stale_timeout` | `1.0` | 超过该秒数没有收到数据包时，将数据流标记为 STALE |
+
 ## 如何确认您的RTK状态
 
 您可以检查``ros2 topic echo /rtcm``，应该有HEX RTCM数据出现，
@@ -137,6 +213,7 @@ ros2 launch ntrip ntrip_launch.py
 | status                   | xsens_mti_driver/XsStatusWord | statusWord, 32bit                                                                                                                             | depending on packet                                                             |
 | temperature              | sensor_msgs/Temperature         | temperature from device                                                                                                                       | 1-400Hz(MTi-600 and MTi-100 series), 1-100Hz(MTi-1 series)                      |
 | tf                       | geometry_msgs/TransformStamped  | transformed orientation                                                                                                                       | 1-400Hz(MTi-600 and MTi-100 series), 1-100Hz(MTi-1 series)                      |
+| diagnostics              | diagnostic_msgs/DiagnosticArray | 设备连接状态、数据流健康状况与解析后的状态字                                                                                 | diagnostics_period（默认 1Hz）                                                |
 | imu/acceleration_hr         | geometry_msgs/Vector3Stamped    | high rate acceleration                                                                                                                       | see xsens_mti_node.yaml                      |
 | imu/angular_velocity_hr     | geometry_msgs/Vector3Stamped    | high rate angular velocity                                                                                                                   | see xsens_mti_node.yaml                      |
 

--- a/src/ntrip/CMakeLists.txt
+++ b/src/ntrip/CMakeLists.txt
@@ -21,13 +21,25 @@ add_library(${PROJECT_NAME}_lib
   src/rtcm_parser.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME}_lib
-  rclcpp
-  nmea_msgs
-  mavros_msgs
-  diagnostic_msgs
-  std_msgs
-)
+if(COMMAND ament_target_dependencies)
+  ament_target_dependencies(${PROJECT_NAME}_lib
+    rclcpp
+    nmea_msgs
+    mavros_msgs
+    diagnostic_msgs
+    std_msgs
+  )
+else()
+  # ament_target_dependencies() was removed on newer ROS releases in favour of
+  # linking the exported CMake targets directly.
+  target_link_libraries(${PROJECT_NAME}_lib
+    rclcpp::rclcpp
+    ${nmea_msgs_TARGETS}
+    ${mavros_msgs_TARGETS}
+    ${diagnostic_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+  )
+endif()
 
 target_link_libraries(${PROJECT_NAME}_lib
   Boost::system
@@ -40,9 +52,15 @@ target_link_libraries(ntrip
   ${PROJECT_NAME}_lib
 )
 
-ament_target_dependencies(ntrip
-  rclcpp
-)
+if(COMMAND ament_target_dependencies)
+  ament_target_dependencies(ntrip
+    rclcpp
+  )
+else()
+  target_link_libraries(ntrip
+    rclcpp::rclcpp
+  )
+endif()
 
 install(TARGETS
   ${PROJECT_NAME}_lib

--- a/src/xsens_mti_ros2_driver/CMakeLists.txt
+++ b/src/xsens_mti_ros2_driver/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 # Find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -87,6 +90,8 @@ add_executable(
 	src/ntrip_util.cpp
 	src/xsens_time_handler.cpp
   src/high_rate_interpolator.cpp
+	src/xsens_diagnostics.cpp
+	src/xsens_mti_lifecycle_node.cpp
 )
 
 # Make sure xsens_mti_node depends on the xspublic build
@@ -98,18 +103,40 @@ add_dependencies(xsens_mti_node xspublic ${PROJECT_NAME})
 #   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp> 
 #   $<INSTALL_INTERFACE:include>)
 
-ament_target_dependencies(xsens_mti_node 
-	rclcpp
-	tf2
-	tf2_ros
-	std_msgs
-	geometry_msgs
-	sensor_msgs
-	nav_msgs
-	nmea_msgs
-	mavros_msgs
-	rosidl_default_runtime
-)
+if(COMMAND ament_target_dependencies)
+	ament_target_dependencies(xsens_mti_node
+		rclcpp
+		rclcpp_lifecycle
+		lifecycle_msgs
+		diagnostic_msgs
+		tf2
+		tf2_ros
+		std_msgs
+		geometry_msgs
+		sensor_msgs
+		nav_msgs
+		nmea_msgs
+		mavros_msgs
+		rosidl_default_runtime
+	)
+else()
+	# ament_target_dependencies() was removed on newer ROS releases in favour of
+	# linking the exported CMake targets directly.
+	target_link_libraries(xsens_mti_node
+		rclcpp::rclcpp
+		rclcpp_lifecycle::rclcpp_lifecycle
+		tf2::tf2
+		tf2_ros::tf2_ros
+		${lifecycle_msgs_TARGETS}
+		${diagnostic_msgs_TARGETS}
+		${std_msgs_TARGETS}
+		${geometry_msgs_TARGETS}
+		${sensor_msgs_TARGETS}
+		${nav_msgs_TARGETS}
+		${nmea_msgs_TARGETS}
+		${mavros_msgs_TARGETS}
+	)
+endif()
 
 # Handle typesupport linking differently based on ROS distro
 if(${ROS_DISTRO} STREQUAL "foxy")
@@ -178,6 +205,9 @@ install(DIRECTORY headers/
 #the dependencies listed inside ament_export_dependencies will be made available to that dependent package.
 ament_export_dependencies(
 	rclcpp
+	rclcpp_lifecycle
+	lifecycle_msgs
+	diagnostic_msgs
 	tf2
 	tf2_ros
 	std_msgs

--- a/src/xsens_mti_ros2_driver/include/high_rate_interpolator.h
+++ b/src/xsens_mti_ros2_driver/include/high_rate_interpolator.h
@@ -2,6 +2,7 @@
 #define HIGH_RATE_INTERPOLATOR_H
 
 #include <rclcpp/rclcpp.hpp>
+#include "xsens_driver_types.h"
 #include <xstypes/xsdatapacket.h>
 #include <xstypes/xsquaternion.h>
 #include <xstypes/xsvector.h>
@@ -30,7 +31,7 @@ struct TimedAcceleration
 class HighRateInterpolator
 {
 public:
-    HighRateInterpolator(rclcpp::Node::SharedPtr node, size_t bufferSize = 10);
+    HighRateInterpolator(DriverNode::SharedPtr node, size_t bufferSize = 10);
     ~HighRateInterpolator();
 
     // Process incoming packet and return interpolated packet if ready
@@ -56,7 +57,7 @@ private:
     void cleanOldData(uint32_t currentTime);
 
 private:
-    rclcpp::Node::SharedPtr m_node;
+    DriverNode::SharedPtr m_node;
     size_t m_bufferSize;
     
     std::mutex m_mutex;

--- a/src/xsens_mti_ros2_driver/include/xdacallback.h
+++ b/src/xsens_mti_ros2_driver/include/xdacallback.h
@@ -34,25 +34,32 @@
 #define XDACALLBACK_H
 
 #include <rclcpp/rclcpp.hpp>
+#include "xsens_driver_types.h"
 #include <xscontroller/xscallback.h>
 #include <mutex>
 #include <condition_variable>
 #include <list>
+#include <memory>
 #include "xsens_time_handler.h"
 #include "high_rate_interpolator.h"
 
 struct XsDataPacket;
 struct XsDevice;
 
+class XsensDiagnostics;
+
 typedef std::pair<rclcpp::Time, XsDataPacket> RosXsDataPacket;
 
 class XdaCallback : public XsCallback
 {
 public:
-	XdaCallback(rclcpp::Node::SharedPtr node, size_t maxBufferSize = 5);
+	XdaCallback(DriverNode::SharedPtr node, size_t maxBufferSize = 5);
 	virtual ~XdaCallback() throw();
 
 	RosXsDataPacket next(const std::chrono::milliseconds &timeout);
+
+	//! \brief Attach the diagnostics collector that device errors are reported to.
+	void setDiagnostics(std::shared_ptr<XsensDiagnostics> diagnostics);
 
 protected:
 	void onLiveDataAvailable(XsDevice *, const XsDataPacket *packet) override;
@@ -66,11 +73,12 @@ private:
 	std::condition_variable m_condition;
 	std::list<RosXsDataPacket> m_buffer;
 	size_t m_maxBufferSize;
-	rclcpp::Node::SharedPtr parent_node;
+	DriverNode::SharedPtr parent_node;
 
 	XsensTimeHandler m_timeHandler;
 	HighRateInterpolator m_interpolator;
 	bool m_interpolationEnabled;
+	std::shared_ptr<XsensDiagnostics> m_diagnostics;
 };
 
 #endif

--- a/src/xsens_mti_ros2_driver/include/xdainterface.h
+++ b/src/xsens_mti_ros2_driver/include/xdainterface.h
@@ -34,6 +34,7 @@
 #define XDAINTERFACE_H
 
 #include <rclcpp/rclcpp.hpp>
+#include "xsens_driver_types.h"
 #include <mavros_msgs/msg/rtcm.hpp>
 #include "xdacallback.h"
 #include <xstypes/xsportinfo.h>
@@ -41,6 +42,7 @@
 #include "std_msgs/msg/empty.hpp"
 
 #include <chrono>
+#include <memory>
 
 struct XsControl;
 struct XsDevice;
@@ -48,11 +50,12 @@ struct XsString;
 struct XsPortInfo;
 
 class PacketCallback;
+class XsensDiagnostics;
 
 class XdaInterface
 {
 public:
-	explicit XdaInterface(rclcpp::Node::SharedPtr node);
+	explicit XdaInterface(DriverNode::SharedPtr node);
 	~XdaInterface();
 
 	void spinFor(std::chrono::milliseconds timeout);
@@ -60,13 +63,26 @@ public:
 	void rtcmCallback(const mavros_msgs::msg::RTCM::SharedPtr msg);
 
 	bool connectDevice();
+
+	//! \brief Apply the device configuration. Maps onto the 'configuring' transition.
+	bool configureDevice();
+	//! \brief Put the device into measurement mode. Maps onto the 'activating' transition.
+	bool startMeasurement();
+	//! \brief Take the device out of measurement mode. Maps onto the 'deactivating' transition.
+	void stopMeasurement();
+
+	//! \brief Convenience wrapper around configureDevice() and startMeasurement().
 	bool prepare();
 	void close();
 
 	void setupManualGyroBiasEstimation();
 
+	//! \brief Attach the diagnostics collector that is fed with every received packet.
+	void setDiagnostics(std::shared_ptr<XsensDiagnostics> diagnostics);
+
 private:
 	void registerCallback(PacketCallback *cb);
+	void clearCallbacks();
 	bool handleError(std::string error);
 	void declareCommonParameters();
 	bool configureSensorSettings();
@@ -78,11 +94,12 @@ private:
 	XsPortInfo m_port;
 	XdaCallback m_xdaCallback;
 	std::list<PacketCallback *> m_callbacks;
-	rclcpp::Node::SharedPtr m_node; 
+	DriverNode::SharedPtr m_node; 
 	// Timer for Manual Gyro Bias Estimation
 	rclcpp::TimerBase::SharedPtr m_manualGyroBiasTimer;
 	rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr m_manualGyroBiasSubscriber;
 	rclcpp::Subscription<mavros_msgs::msg::RTCM>::SharedPtr m_rtcmSubscription;
+	std::shared_ptr<XsensDiagnostics> m_diagnostics;
 };
 
 #endif

--- a/src/xsens_mti_ros2_driver/include/xsens_diagnostics.h
+++ b/src/xsens_mti_ros2_driver/include/xsens_diagnostics.h
@@ -1,0 +1,99 @@
+//  Diagnostics publishing for the Xsens MTi ROS 2 driver.
+//  Distributed under the same BSD license as the rest of this package.
+
+
+#ifndef XSENS_DIAGNOSTICS_H
+#define XSENS_DIAGNOSTICS_H
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <xstypes/xsdatapacket.h>
+
+#include <mutex>
+#include <string>
+
+#include "xsens_driver_types.h"
+
+//! \brief Collects driver health information and publishes it on /diagnostics.
+//!
+//! Three statuses are published: the state of the device connection, the health
+//! of the measurement stream (rate, staleness) and a decoded view of the last
+//! MTi status word. Sampling methods are safe to call from the XDA callback
+//! thread; publishing happens on the node's executor thread.
+class XsensDiagnostics
+{
+public:
+	explicit XsensDiagnostics(DriverNode::SharedPtr node);
+
+	//! \brief Declare the diagnostics parameters on the node.
+	void declareParameters();
+
+	//! \brief Create the /diagnostics publisher. Called from on_configure().
+	void configure();
+	//! \brief Start the periodic publish timer. Called from on_activate().
+	void activate();
+	//! \brief Stop the periodic publish timer. Called from on_deactivate().
+	void deactivate();
+	//! \brief Release publisher and timer. Called from on_cleanup().
+	void cleanup();
+
+	//! \brief Whether diagnostics publishing is enabled by parameter.
+	bool enabled() const
+	{
+		return m_enabled;
+	}
+
+	void setDeviceInfo(const std::string &product_code, const std::string &device_id,
+					   const std::string &firmware, const std::string &port, int baudrate);
+	void setConnected(bool connected);
+	void setMeasuring(bool measuring);
+
+	//! \brief Account for one packet handed to the message publishers.
+	void recordPacket(const XsDataPacket &packet);
+	//! \brief Account for one error reported by the device.
+	void recordDeviceError(const std::string &error);
+
+	//! \brief Assemble and publish a DiagnosticArray. Normally driven by a timer.
+	void publish();
+
+private:
+	diagnostic_msgs::msg::DiagnosticStatus deviceStatus(uint32_t errors_in_window) const;
+	diagnostic_msgs::msg::DiagnosticStatus streamStatus(const rclcpp::Time &now, double rate);
+	diagnostic_msgs::msg::DiagnosticStatus filterStatus(uint32_t status_word) const;
+
+	DriverNode::SharedPtr m_node;
+	DriverPublisher<diagnostic_msgs::msg::DiagnosticArray> m_pub;
+	rclcpp::TimerBase::SharedPtr m_timer;
+
+	// Parameters
+	bool m_enabled = true;
+	double m_period = 1.0;
+	double m_minRate = 0.0;
+	double m_staleTimeout = 1.0;
+
+	mutable std::mutex m_mutex;
+	std::string m_productCode;
+	std::string m_deviceId;
+	std::string m_firmware;
+	std::string m_portName;
+	int m_baudrate = 0;
+	bool m_connected = false;
+	bool m_measuring = false;
+
+	uint64_t m_packetCount = 0;
+	uint64_t m_packetCountAtLastReport = 0;
+	rclcpp::Time m_lastPacketTime;
+	bool m_hasPacketTime = false;
+
+	uint32_t m_statusWord = 0;
+	bool m_hasStatusWord = false;
+
+	uint32_t m_errorCount = 0;
+	uint32_t m_errorCountAtLastReport = 0;
+	std::string m_lastError;
+
+	rclcpp::Time m_lastReportTime;
+	bool m_hasReportTime = false;
+};
+
+#endif

--- a/src/xsens_mti_ros2_driver/include/xsens_driver_types.h
+++ b/src/xsens_mti_ros2_driver/include/xsens_driver_types.h
@@ -1,0 +1,20 @@
+//  Shared node/publisher type aliases for the Xsens MTi ROS 2 driver.
+//  Distributed under the same BSD license as the rest of this package.
+
+
+#ifndef XSENS_DRIVER_TYPES_H
+#define XSENS_DRIVER_TYPES_H
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <rclcpp_lifecycle/lifecycle_publisher.hpp>
+
+// The driver runs as a managed (lifecycle) node. Publishers created through it
+// are lifecycle publishers, which only put messages on the wire while the node
+// is in the 'active' state.
+using DriverNode = rclcpp_lifecycle::LifecycleNode;
+
+template <typename MessageT>
+using DriverPublisher = typename rclcpp_lifecycle::LifecyclePublisher<MessageT>::SharedPtr;
+
+#endif

--- a/src/xsens_mti_ros2_driver/include/xsens_mti_lifecycle_node.h
+++ b/src/xsens_mti_ros2_driver/include/xsens_mti_lifecycle_node.h
@@ -1,0 +1,63 @@
+//  Managed (lifecycle) node wrapper for the Xsens MTi ROS 2 driver.
+//  Distributed under the same BSD license as the rest of this package.
+
+
+#ifndef XSENS_MTI_LIFECYCLE_NODE_H
+#define XSENS_MTI_LIFECYCLE_NODE_H
+
+#include <chrono>
+#include <memory>
+
+#include "xsens_driver_types.h"
+
+class XdaInterface;
+class XsensDiagnostics;
+
+//! \brief The driver as a managed node.
+//!
+//! The lifecycle states map onto the device as follows:
+//!  - configuring:  open the port, create the publishers, write the device configuration
+//!  - activating:   put the device into measurement mode, start diagnostics reporting
+//!  - deactivating: put the device back into config mode, stop publishing
+//!  - cleaning up:  close the port and destroy the publishers
+class XsensMtiLifecycleNode : public DriverNode
+{
+public:
+	using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+	explicit XsensMtiLifecycleNode(const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+	~XsensMtiLifecycleNode() override;
+
+	//! \brief Whether the node should walk itself into the active state on startup.
+	bool autostart() const;
+	//! \brief Whether the device is streaming and the publishers are activated.
+	bool isActive() const;
+
+	//! \brief Hand any pending device data to the message publishers.
+	//! Does nothing unless the node is active.
+	void pumpDeviceData(std::chrono::milliseconds timeout);
+
+	//! \brief Stop the device and release everything the node holds.
+	//!
+	//! The driver objects owned by this node hold a shared reference back to it,
+	//! so the node cannot destroy itself while they are alive. Call this before
+	//! dropping the last reference to the node (the lifecycle 'shutdown'
+	//! transition does it too) so the port is closed and recording is stopped.
+	void shutdownDriver();
+
+	CallbackReturn on_configure(const rclcpp_lifecycle::State &previous_state) override;
+	CallbackReturn on_activate(const rclcpp_lifecycle::State &previous_state) override;
+	CallbackReturn on_deactivate(const rclcpp_lifecycle::State &previous_state) override;
+	CallbackReturn on_cleanup(const rclcpp_lifecycle::State &previous_state) override;
+	CallbackReturn on_shutdown(const rclcpp_lifecycle::State &previous_state) override;
+	CallbackReturn on_error(const rclcpp_lifecycle::State &previous_state) override;
+
+private:
+	void releaseDevice();
+
+	std::shared_ptr<XdaInterface> m_interface;
+	std::shared_ptr<XsensDiagnostics> m_diagnostics;
+	bool m_active = false;
+};
+
+#endif

--- a/src/xsens_mti_ros2_driver/package.xml
+++ b/src/xsens_mti_ros2_driver/package.xml
@@ -11,6 +11,9 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
+  <build_depend>lifecycle_msgs</build_depend>
+  <build_depend>diagnostic_msgs</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -21,6 +24,9 @@
   <build_depend>mavros_msgs</build_depend>
   
   <build_export_depend>rclcpp</build_export_depend>
+  <build_export_depend>rclcpp_lifecycle</build_export_depend>
+  <build_export_depend>lifecycle_msgs</build_export_depend>
+  <build_export_depend>diagnostic_msgs</build_export_depend>
   <build_export_depend>tf2</build_export_depend>
   <build_export_depend>tf2_ros</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
@@ -30,6 +36,9 @@
   <build_export_depend>nmea_msgs</build_export_depend>
   <build_export_depend>mavros_msgs</build_export_depend>
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_lifecycle</exec_depend>
+  <exec_depend>lifecycle_msgs</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
+++ b/src/xsens_mti_ros2_driver/param/xsens_mti_node.yaml
@@ -34,6 +34,32 @@
         # Example: device_id: '00800210C2'
         #device_id: '00800210C2'
 
+        # Lifecycle Configuration
+        # -----------------------
+        # The driver is a managed (lifecycle) node. With 'autostart' set to true it
+        # configures and activates itself on startup, which is how the node has
+        # always behaved. Set it to false to drive the transitions yourself, e.g.:
+        #   ros2 lifecycle set /xsens_driver configure
+        #   ros2 lifecycle set /xsens_driver activate
+        # While the node is inactive the device is kept out of measurement mode and
+        # no messages are published.
+        autostart: true
+
+        # Diagnostics Configuration
+        # -------------------------
+        # Publishes diagnostic_msgs/DiagnosticArray on /diagnostics while the node
+        # is active, with the device connection state, the health of the measurement
+        # stream and a decoded view of the MTi status word.
+        diagnostics_enabled: true
+        # Publishing period in seconds.
+        diagnostics_period: 1.0
+        # Warn when the measured packet rate drops below this value, in Hz.
+        # Set to 0.0 to disable the check. A sensible value is somewhat below the
+        # configured output_data_rate.
+        diagnostics_min_rate: 0.0
+        # Report the stream as stale when no packet arrived for this many seconds.
+        diagnostics_stale_timeout: 1.0
+
         # Publisher Configuration
         publisher_queue_size: 5
 

--- a/src/xsens_mti_ros2_driver/param/xsens_mti_node_mti320.yaml
+++ b/src/xsens_mti_ros2_driver/param/xsens_mti_node_mti320.yaml
@@ -34,6 +34,32 @@
         # Example: device_id: '00800210C2'
         #device_id: '00800210C2'
 
+        # Lifecycle Configuration
+        # -----------------------
+        # The driver is a managed (lifecycle) node. With 'autostart' set to true it
+        # configures and activates itself on startup, which is how the node has
+        # always behaved. Set it to false to drive the transitions yourself, e.g.:
+        #   ros2 lifecycle set /xsens_driver configure
+        #   ros2 lifecycle set /xsens_driver activate
+        # While the node is inactive the device is kept out of measurement mode and
+        # no messages are published.
+        autostart: true
+
+        # Diagnostics Configuration
+        # -------------------------
+        # Publishes diagnostic_msgs/DiagnosticArray on /diagnostics while the node
+        # is active, with the device connection state, the health of the measurement
+        # stream and a decoded view of the MTi status word.
+        diagnostics_enabled: true
+        # Publishing period in seconds.
+        diagnostics_period: 1.0
+        # Warn when the measured packet rate drops below this value, in Hz.
+        # Set to 0.0 to disable the check. A sensible value is somewhat below the
+        # configured output_data_rate.
+        diagnostics_min_rate: 0.0
+        # Report the stream as stale when no packet arrived for this many seconds.
+        diagnostics_stale_timeout: 1.0
+
         # Publisher Configuration
         publisher_queue_size: 5
 

--- a/src/xsens_mti_ros2_driver/src/high_rate_interpolator.cpp
+++ b/src/xsens_mti_ros2_driver/src/high_rate_interpolator.cpp
@@ -2,7 +2,7 @@
 #include <cmath>
 #include <algorithm>
 
-HighRateInterpolator::HighRateInterpolator(rclcpp::Node::SharedPtr node, size_t bufferSize)
+HighRateInterpolator::HighRateInterpolator(DriverNode::SharedPtr node, size_t bufferSize)
     : m_node(node)
     , m_bufferSize(bufferSize)
     , m_isInitialized(false)

--- a/src/xsens_mti_ros2_driver/src/main.cpp
+++ b/src/xsens_mti_ros2_driver/src/main.cpp
@@ -32,54 +32,101 @@
 
 
 #include <rclcpp/rclcpp.hpp>
-#include "xdainterface.h"
+#include <lifecycle_msgs/msg/state.hpp>
+#include "xsens_mti_lifecycle_node.h"
+#include <xscommon/journaller.h>
 #include <mavros_msgs/msg/rtcm.hpp>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <chrono>
+#include <atomic>
+#include <csignal>
 
 using std::chrono::milliseconds;
+using lifecycle_msgs::msg::State;
 
 Journaller *gJournal = 0;
 
+namespace
+{
+std::atomic_bool g_keep_running{true};
+
+void requestStop(int)
+{
+    g_keep_running = false;
+}
+}  // namespace
+
 int main(int argc, char *argv[])
 {
-    rclcpp::init(argc, argv);
+    // Handle the termination signals ourselves so that the lifecycle 'shutdown'
+    // transition still runs on a valid context, which lets the node leave
+    // measurement mode and close the port in an orderly way.
+    rclcpp::InitOptions init_options;
+    init_options.shutdown_on_signal = false;
+    rclcpp::init(argc, argv, init_options);
+
+    std::signal(SIGINT, requestStop);
+    std::signal(SIGTERM, requestStop);
     // Create an executor that will be responsible for execution of callbacks for a set of nodes.
     // With SingleThreadedExecutor, all callbacks will be called from within this thread (the main thread in this case).
     rclcpp::executors::SingleThreadedExecutor exec;
 
-    // Create a node called "xsens_driver"
-    auto node = std::make_shared<rclcpp::Node>("xsens_driver");
+    // Create the managed node called "xsens_driver"
+    auto node = std::make_shared<XsensMtiLifecycleNode>();
     // Add the node to the executor
-    exec.add_node(node);
+    exec.add_node(node->get_node_base_interface());
 
-    // Declare the XdaInterface with the node
-    auto xdaInterface = std::make_shared<XdaInterface>(node);
-    RCLCPP_INFO(node->get_logger(), "XdaInterface has been initialized");
-
-    if (!xdaInterface->connectDevice()) {
-        RCLCPP_ERROR(node->get_logger(), "Failed to connect device");
-        return -1;
-    }
-
-    xdaInterface->registerPublishers();
-
-    if (!xdaInterface->prepare()) {
-        RCLCPP_ERROR(node->get_logger(), "Failed to prepare device");
-        return -1;
-    }
-
-
-    while (rclcpp::ok())
+    // Unless the node is driven externally (autostart:=false), walk it into the
+    // active state right away so that the node behaves as it always has.
+    if (node->autostart())
     {
-        xdaInterface->spinFor(milliseconds(100));
-        exec.spin_some();
+        if (node->configure().id() != State::PRIMARY_STATE_INACTIVE)
+        {
+            RCLCPP_FATAL(node->get_logger(), "Failed to configure the driver");
+            node->shutdownDriver();
+            rclcpp::shutdown();
+            return -1;
+        }
+
+        if (node->activate().id() != State::PRIMARY_STATE_ACTIVE)
+        {
+            RCLCPP_FATAL(node->get_logger(), "Failed to activate the driver");
+            node->shutdownDriver();
+            rclcpp::shutdown();
+            return -1;
+        }
+    }
+    else
+    {
+        RCLCPP_INFO(node->get_logger(),
+                    "Started with autostart:=false. Waiting for lifecycle transitions on ~/change_state.");
     }
 
-    // Reset the xdaInterface pointer to ensure it is destroyed before calling rclcpp::shutdown()
-    xdaInterface.reset();
+    while (rclcpp::ok() && g_keep_running)
+    {
+        if (node->isActive())
+        {
+            // Blocks until a packet arrives or the timeout expires.
+            node->pumpDeviceData(milliseconds(100));
+            exec.spin_some();
+        }
+        else
+        {
+            // Nothing to read from the device, so just wait for lifecycle
+            // service calls instead of spinning hot.
+            exec.spin_once(milliseconds(100));
+        }
+    }
+
+    // Walk the state machine to 'finalized' so that the node is not destroyed
+    // while it is still active.
+    if (rclcpp::ok() && node->get_current_state().id() != State::PRIMARY_STATE_FINALIZED)
+        node->shutdown();
+
+    // Release the device before dropping the last reference to the node.
+    node->shutdownDriver();
 
     rclcpp::shutdown();
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationhrpublisher.h
@@ -37,10 +37,10 @@
 
 struct AccelerationHRPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    AccelerationHRPublisher(rclcpp::Node::SharedPtr node)
+    AccelerationHRPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationpublisher.h
@@ -37,10 +37,10 @@
 
 struct AccelerationPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    AccelerationPublisher(rclcpp::Node::SharedPtr node)
+    AccelerationPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocityhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocityhrpublisher.h
@@ -37,10 +37,10 @@
 
 struct AngularVelocityHRPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    AngularVelocityHRPublisher(rclcpp::Node::SharedPtr node)
+    AngularVelocityHRPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocitypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocitypublisher.h
@@ -37,10 +37,10 @@
 
 struct AngularVelocityPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    AngularVelocityPublisher(rclcpp::Node::SharedPtr node)
+    AngularVelocityPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/freeaccelerationpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/freeaccelerationpublisher.h
@@ -37,10 +37,10 @@
 
 struct FreeAccelerationPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    FreeAccelerationPublisher(rclcpp::Node::SharedPtr node)
+    FreeAccelerationPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/gnssposepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/gnssposepublisher.h
@@ -37,10 +37,10 @@
 
 struct GNSSPOSEPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::PoseStamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    GNSSPOSEPublisher(rclcpp::Node::SharedPtr node)
+    GNSSPOSEPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/gnsspublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/gnsspublisher.h
@@ -42,10 +42,10 @@
 
 struct GnssPublisher : public PacketCallback
 {
-    rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr pub;
+    DriverPublisher<sensor_msgs::msg::NavSatFix> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    GnssPublisher(rclcpp::Node::SharedPtr node)
+    GnssPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/imupublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/imupublisher.h
@@ -40,20 +40,24 @@
 
 struct ImuPublisher : public PacketCallback, PublisherHelperFunctions
 {
-    rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub;
+    DriverPublisher<sensor_msgs::msg::Imu> pub;
     double orientation_variance[3];
     double linear_acceleration_variance[3];
     double angular_velocity_variance[3];
-    rclcpp::Node::SharedPtr node_handle;
+    DriverNode::SharedPtr node_handle;
     XsDevice *m_device;
 
-    ImuPublisher(rclcpp::Node::SharedPtr node, XsDevice *device = nullptr)
+    ImuPublisher(DriverNode::SharedPtr node, XsDevice *device = nullptr)
         : node_handle(node), m_device(device)
     {
         std::vector<double> variance = {0, 0, 0};
-        node->declare_parameter("orientation_stddev", variance);
-        node->declare_parameter("angular_velocity_stddev", variance);
-        node->declare_parameter("linear_acceleration_stddev", variance);
+        // Guarded, because publishers are re-created on every lifecycle configure.
+        if (!node->has_parameter("orientation_stddev"))
+            node->declare_parameter("orientation_stddev", variance);
+        if (!node->has_parameter("angular_velocity_stddev"))
+            node->declare_parameter("angular_velocity_stddev", variance);
+        if (!node->has_parameter("linear_acceleration_stddev"))
+            node->declare_parameter("linear_acceleration_stddev", variance);
 
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/magneticfieldpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/magneticfieldpublisher.h
@@ -39,14 +39,16 @@
 
 struct MagneticFieldPublisher : public PacketCallback, PublisherHelperFunctions
 {
-    rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr pub;
+    DriverPublisher<sensor_msgs::msg::MagneticField> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
     double magnetic_field_variance[3];
 
-    MagneticFieldPublisher(rclcpp::Node::SharedPtr node)
+    MagneticFieldPublisher(DriverNode::SharedPtr node)
     {
         std::vector<double> variance = {0, 0, 0};
-        node->declare_parameter("magnetic_field_stddev", variance);
+        // Guarded, because publishers are re-created on every lifecycle configure.
+        if (!node->has_parameter("magnetic_field_stddev"))
+            node->declare_parameter("magnetic_field_stddev", variance);
 
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/nmeapublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/nmeapublisher.h
@@ -42,7 +42,7 @@
 
 struct NMEAPublisher : public PacketCallback
 {
-    rclcpp::Publisher<nmea_msgs::msg::Sentence>::SharedPtr pub;
+    DriverPublisher<nmea_msgs::msg::Sentence> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
     rclcpp::Logger logger; // Store the logger
 
@@ -50,7 +50,7 @@ struct NMEAPublisher : public PacketCallback
     bool new_data_available = false;
     int packet_counter = 0; // Counter to track the number of packets received
 
-    NMEAPublisher(rclcpp::Node::SharedPtr node)
+    NMEAPublisher(DriverNode::SharedPtr node)
     : logger(node->get_logger()) // Initialize the logger
     {
         int pub_queue_size = 5;

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/odometrypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/odometrypublisher.h
@@ -34,14 +34,19 @@
 #include "packetcallback.h"
 #include <nav_msgs/msg/odometry.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+// The .h spelling was removed on newer ROS releases.
+#if __has_include(<tf2/LinearMath/Quaternion.hpp>)
+#include <tf2/LinearMath/Quaternion.hpp>
+#else
 #include <tf2/LinearMath/Quaternion.h>
+#endif
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <cmath>
 
 struct ODOMETRYPublisher : public PacketCallback
 {
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub;
+    DriverPublisher<nav_msgs::msg::Odometry> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
     std::string odom_init_frame_id = "odom_init";
     std::string base_frame_id = "base_link"; 
@@ -62,7 +67,7 @@ struct ODOMETRYPublisher : public PacketCallback
     double m_latitude = 0.0;
     double m_longitude = 0.0;
 
-    ODOMETRYPublisher(rclcpp::Node::SharedPtr node)
+    ODOMETRYPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/orientationeulerpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/orientationeulerpublisher.h
@@ -37,10 +37,10 @@
 
 struct OrientationEulerPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    OrientationEulerPublisher(rclcpp::Node::SharedPtr node)
+    OrientationEulerPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/orientationincrementspublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/orientationincrementspublisher.h
@@ -37,10 +37,10 @@
 
 struct OrientationIncrementsPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::QuaternionStamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::QuaternionStamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    OrientationIncrementsPublisher(rclcpp::Node::SharedPtr node)
+    OrientationIncrementsPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/orientationpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/orientationpublisher.h
@@ -37,10 +37,10 @@
 
 struct OrientationPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::QuaternionStamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::QuaternionStamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    OrientationPublisher(rclcpp::Node::SharedPtr node)
+    OrientationPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/packetcallback.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/packetcallback.h
@@ -35,12 +35,14 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <xstypes/xsdatapacket.h>
+#include "xsens_driver_types.h"
 
 const char* DEFAULT_FRAME_ID = "imu_link";
 
 class PacketCallback
 {
     public:
+        virtual ~PacketCallback() = default;
         virtual void operator()(const XsDataPacket &, rclcpp::Time) = 0;
 };
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/positionllapublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/positionllapublisher.h
@@ -37,11 +37,11 @@
 
 struct PositionLLAPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
 
-    PositionLLAPublisher(rclcpp::Node::SharedPtr node)
+    PositionLLAPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/pressurepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/pressurepublisher.h
@@ -37,10 +37,10 @@
 
 struct PressurePublisher : public PacketCallback
 {
-    rclcpp::Publisher<sensor_msgs::msg::FluidPressure>::SharedPtr pub;
+    DriverPublisher<sensor_msgs::msg::FluidPressure> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    PressurePublisher(rclcpp::Node::SharedPtr node)
+    PressurePublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/publisherhelperfunctions.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/publisherhelperfunctions.h
@@ -42,7 +42,7 @@ public:
     PublisherHelperFunctions(/* args */);
     ~PublisherHelperFunctions();
 
-    void variance_from_stddev_param(std::string param, double *variance_out, rclcpp::Node::SharedPtr node_handle)
+    void variance_from_stddev_param(std::string param, double *variance_out, DriverNode::SharedPtr node_handle)
     {
         std::vector<double> stddev;
         if (node_handle->get_parameter(param, stddev))

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/shipmotionpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/shipmotionpublisher.h
@@ -38,10 +38,10 @@
 
 struct ShipMotionPublisher : public PacketCallback
 {
-    rclcpp::Publisher<xsens_mti_ros2_driver::msg::ShipMotion>::SharedPtr pub;
+    DriverPublisher<xsens_mti_ros2_driver::msg::ShipMotion> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
     
-    ShipMotionPublisher(rclcpp::Node::SharedPtr node)
+    ShipMotionPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/statuspublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/statuspublisher.h
@@ -39,10 +39,10 @@
 
 struct StatusPublisher : public PacketCallback
 {
-    rclcpp::Publisher<xsens_mti_ros2_driver::msg::XsStatusWord>::SharedPtr pub;
+    DriverPublisher<xsens_mti_ros2_driver::msg::XsStatusWord> pub;
     //std::string frame_id = DEFAULT_FRAME_ID;
 
-    StatusPublisher(rclcpp::Node::SharedPtr node)
+    StatusPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/temperaturepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/temperaturepublisher.h
@@ -38,10 +38,10 @@
 
 struct TemperaturePublisher : public PacketCallback
 {
-    rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr pub;
+    DriverPublisher<sensor_msgs::msg::Temperature> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    TemperaturePublisher(rclcpp::Node::SharedPtr node)
+    TemperaturePublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/timereferencepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/timereferencepublisher.h
@@ -38,9 +38,9 @@
 
 struct TimeReferencePublisher : public PacketCallback
 {
-    rclcpp::Publisher<sensor_msgs::msg::TimeReference>::SharedPtr pub;
+    DriverPublisher<sensor_msgs::msg::TimeReference> pub;
 
-    TimeReferencePublisher(rclcpp::Node::SharedPtr node)
+    TimeReferencePublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/transformpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/transformpublisher.h
@@ -43,7 +43,7 @@ struct TransformPublisher : public PacketCallback
     tf2_ros::TransformBroadcaster tf_broadcaster;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    TransformPublisher(rclcpp::Node::SharedPtr node) : tf_broadcaster(node)
+    TransformPublisher(DriverNode::SharedPtr node) : tf_broadcaster(node)
     {
         node->get_parameter("frame_id", frame_id);
     }

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/twistpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/twistpublisher.h
@@ -38,10 +38,10 @@
 
 struct TwistPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::TwistStamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    TwistPublisher(rclcpp::Node::SharedPtr node)
+    TwistPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/utctimepublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/utctimepublisher.h
@@ -38,9 +38,9 @@
 
 struct UTCTimePublisher : public PacketCallback
 {
-    rclcpp::Publisher<sensor_msgs::msg::TimeReference>::SharedPtr pub;
+    DriverPublisher<sensor_msgs::msg::TimeReference> pub;
 
-    UTCTimePublisher(rclcpp::Node::SharedPtr node)
+    UTCTimePublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/velocityincrementpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/velocityincrementpublisher.h
@@ -37,10 +37,10 @@
 
 struct VelocityIncrementPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
-    VelocityIncrementPublisher(rclcpp::Node::SharedPtr node)
+    VelocityIncrementPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/velocitypublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/velocitypublisher.h
@@ -38,11 +38,11 @@
 
 struct VelocityPublisher : public PacketCallback
 {
-    rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub;
+    DriverPublisher<geometry_msgs::msg::Vector3Stamped> pub;
     std::string frame_id = DEFAULT_FRAME_ID;
 
 
-    VelocityPublisher(rclcpp::Node::SharedPtr node)
+    VelocityPublisher(DriverNode::SharedPtr node)
     {
         int pub_queue_size = 5;
         node->get_parameter("publisher_queue_size", pub_queue_size);

--- a/src/xsens_mti_ros2_driver/src/xdacallback.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdacallback.cpp
@@ -35,14 +35,18 @@
 #include <xscontroller/xsdevice_def.h>
 #include <xstypes/xsdatapacket.h>
 
-XdaCallback::XdaCallback(rclcpp::Node::SharedPtr node, size_t maxBufferSize)
+#include "xsens_diagnostics.h"
+
+XdaCallback::XdaCallback(DriverNode::SharedPtr node, size_t maxBufferSize)
 	: m_maxBufferSize(maxBufferSize)
 	, parent_node(node)
 	, m_interpolator(node)
 	, m_interpolationEnabled(false)
 {
 	int time_option = 0; //default is "mti_utc"
-	parent_node->declare_parameter<int>("time_option", 0);
+	// Guarded, because a new callback object is created on every lifecycle configure.
+	if (!parent_node->has_parameter("time_option"))
+		parent_node->declare_parameter<int>("time_option", 0);
 	parent_node->get_parameter("time_option", time_option);
 	m_timeHandler.setTimeOption(time_option);
 	//if else to check time_option rosinfo to print time_option
@@ -221,9 +225,16 @@ void XdaCallback::onLiveDataAvailable(XsDevice *, const XsDataPacket *packet)
 	}
 }
 
+void XdaCallback::setDiagnostics(std::shared_ptr<XsensDiagnostics> diagnostics)
+{
+	m_diagnostics = diagnostics;
+}
+
 void XdaCallback::onError(XsDevice *dev, XsResultValue error)
 {
 	RCLCPP_ERROR(parent_node->get_logger(), "MTi Error: %s", XsResultValue_toString(error));
+	if (m_diagnostics)
+		m_diagnostics->recordDeviceError(XsResultValue_toString(error));
 	if(error == XRV_DATAOVERFLOW)
 	{
 		RCLCPP_ERROR(parent_node->get_logger(), "Data overflow occurred. Use MT Manager - Device Settings, to change the baudrate to higher value like 921600 or 2000000!! Optionally, change the enable_deviceConfig to true to change the output in the xsens_mti_node.yaml. If both doesn't work, reduce your output data rate.");

--- a/src/xsens_mti_ros2_driver/src/xdainterface.cpp
+++ b/src/xsens_mti_ros2_driver/src/xdainterface.cpp
@@ -68,12 +68,13 @@
 #include "messagepublishers/odometrypublisher.h"
 #include "messagepublishers/shipmotionpublisher.h"
 #include "xsens_log_handler.h"
+#include "xsens_diagnostics.h"
 
 #include <chrono>
 
 #define XS_DEFAULT_BAUDRATE (115200)
 
-XdaInterface::XdaInterface(rclcpp::Node::SharedPtr node)
+XdaInterface::XdaInterface(DriverNode::SharedPtr node)
     : m_device(nullptr), m_xdaCallback(node), m_node(node), m_productCode("")
 {
 	RCLCPP_INFO(node->get_logger(), "Creating XsControl object...");
@@ -89,12 +90,21 @@ XdaInterface::~XdaInterface()
 	m_control->destruct();
 }
 
+void XdaInterface::setDiagnostics(std::shared_ptr<XsensDiagnostics> diagnostics)
+{
+	m_diagnostics = diagnostics;
+	m_xdaCallback.setDiagnostics(diagnostics);
+}
+
 void XdaInterface::spinFor(std::chrono::milliseconds timeout)
 {
 	RosXsDataPacket rosPacket = m_xdaCallback.next(timeout);
 
 	if (!rosPacket.second.empty())
 	{
+		if (m_diagnostics)
+			m_diagnostics->recordPacket(rosPacket.second);
+
 		for (auto &cb : m_callbacks)
 		{
 			cb->operator()(rosPacket.second, rosPacket.first);
@@ -332,6 +342,10 @@ bool XdaInterface::connectDevice()
 	if (!m_control->openPort(mtPort))
 		return handleError("Could not open port");
 
+	// Remember the port so that close() can actually release it again, which the
+	// lifecycle 'cleanup' transition relies on.
+	m_port = mtPort;
+
 	m_device = m_control->device(mtPort.deviceId());
 	assert(m_device != 0);
 
@@ -384,11 +398,21 @@ bool XdaInterface::connectDevice()
 
 	m_device->addCallbackHandler(&m_xdaCallback);
 
+	if (m_diagnostics)
+	{
+		m_diagnostics->setDeviceInfo(m_productCode.toStdString(),
+									 m_device->deviceId().toString().toStdString(),
+									 firmwareVersion.toString().toStdString(),
+									 mtPort.portName().toStdString(),
+									 XsBaud::rateToNumeric(mtPort.baudrate()));
+		m_diagnostics->setConnected(true);
+	}
+
 	return true;
 }
 
 
-bool XdaInterface::prepare()
+bool XdaInterface::configureDevice()
 {
 	assert(m_device != 0);
 
@@ -420,12 +444,23 @@ bool XdaInterface::prepare()
 	if (!m_device->readEmtsAndDeviceConfiguration())
 		return handleError("Could not read device configuration");
 
+	return true;
+}
+
+
+bool XdaInterface::startMeasurement()
+{
+	assert(m_device != 0);
+
 	RCLCPP_INFO(m_node->get_logger(), "Measuring ..");
 	if (!m_device->gotoMeasurement())
 		return handleError("Could not put device into measurement mode");
 
+	if (m_diagnostics)
+		m_diagnostics->setMeasuring(true);
+
 	bool enable_logging = false;
-	
+
 	if(m_node->get_parameter("enable_logging", enable_logging) && enable_logging)
 	{
 		XsensLogHandler logHandler;
@@ -444,7 +479,7 @@ bool XdaInterface::prepare()
 
 	//delay 0.05 second, as the previous actions might take a little delay.
 	rclcpp::sleep_for(std::chrono::milliseconds(50));
-	
+
 	//in any case, send MGBE in the beginning for 6 seconds.
 	manualGyroBiasEstimation(0, 6);
 
@@ -452,6 +487,34 @@ bool XdaInterface::prepare()
     setupManualGyroBiasEstimation();
 
 	return true;
+}
+
+
+void XdaInterface::stopMeasurement()
+{
+	// Drop the periodic gyro bias estimation so it is not re-created on the next
+	// activation and does not talk to a device that is back in config mode.
+	m_manualGyroBiasTimer.reset();
+	m_manualGyroBiasSubscriber.reset();
+
+	if (m_device != nullptr)
+	{
+		m_device->stopRecording();
+		m_device->closeLogFile();
+
+		RCLCPP_INFO(m_node->get_logger(), "Leaving measurement mode ..");
+		if (!m_device->gotoConfig())
+			RCLCPP_WARN(m_node->get_logger(), "Could not put device back into config mode.");
+	}
+
+	if (m_diagnostics)
+		m_diagnostics->setMeasuring(false);
+}
+
+
+bool XdaInterface::prepare()
+{
+	return configureDevice() && startMeasurement();
 }
 
 
@@ -501,8 +564,11 @@ void XdaInterface::setupManualGyroBiasEstimation()
     bool enable_manual_gyro_bias = false;
 	//assign default value {10,3} to manual_gyro_bias_param
     std::vector<long int>  manual_gyro_bias_param = {10, 3};
-	m_node->declare_parameter("enable_manual_gyro_bias", enable_manual_gyro_bias);
-	m_node->declare_parameter("manual_gyro_bias_param",manual_gyro_bias_param);
+	// Guarded, because this runs again on every lifecycle activation.
+	if (!m_node->has_parameter("enable_manual_gyro_bias"))
+		m_node->declare_parameter("enable_manual_gyro_bias", enable_manual_gyro_bias);
+	if (!m_node->has_parameter("manual_gyro_bias_param"))
+		m_node->declare_parameter("manual_gyro_bias_param",manual_gyro_bias_param);
 
 	if(m_node->get_parameter("enable_manual_gyro_bias", enable_manual_gyro_bias) && m_node->get_parameter("manual_gyro_bias_param", manual_gyro_bias_param))
 	{
@@ -570,13 +636,26 @@ void XdaInterface::rtcmCallback(const mavros_msgs::msg::RTCM::SharedPtr msg)
 
 void XdaInterface::close()
 {
+	m_manualGyroBiasTimer.reset();
+	m_manualGyroBiasSubscriber.reset();
+	m_rtcmSubscription.reset();
+
 	if (m_device != nullptr)
 	{
 		m_device->stopRecording();
 		m_device->closeLogFile();
 		m_device->removeCallbackHandler(&m_xdaCallback);
+		m_device = nullptr;
 	}
 	m_control->closePort(m_port);
+
+	clearCallbacks();
+
+	if (m_diagnostics)
+	{
+		m_diagnostics->setMeasuring(false);
+		m_diagnostics->setConnected(false);
+	}
 }
 
 
@@ -584,6 +663,15 @@ void XdaInterface::close()
 void XdaInterface::registerCallback(PacketCallback *cb)
 {
 	m_callbacks.push_back(cb);
+}
+
+void XdaInterface::clearCallbacks()
+{
+	for (auto &cb : m_callbacks)
+	{
+		delete cb;
+	}
+	m_callbacks.clear();
 }
 
 bool XdaInterface::handleError(std::string error)
@@ -961,7 +1049,8 @@ bool XdaInterface::configureSensorSettings()
 			if(m_node->get_parameter("enable_rotsensor_frame_config", enable_rotsensor_frame_config)&& enable_rotsensor_frame_config)
 			{
 				std::vector<double> rotsensor_rotation_euler = {0.0, 0.0, 0.0};
-				m_node->declare_parameter("rotsensor_rotation_euler",rotsensor_rotation_euler);
+				if (!m_node->has_parameter("rotsensor_rotation_euler"))
+					m_node->declare_parameter("rotsensor_rotation_euler",rotsensor_rotation_euler);
 				if(m_node->get_parameter("rotsensor_rotation_euler", rotsensor_rotation_euler))
 				{
 					//change sensor's RotSensor frame by euler angles, roll, pitch, yaw
@@ -1144,7 +1233,8 @@ bool XdaInterface::configureSensorSettings()
 		if (xsens_device_id.isRtk())
 		{
 			std::vector<double> gnssLeverArm = {0.0, 0.0, 0.0};
-			m_node->declare_parameter("GNSS_LeverArm",gnssLeverArm);
+			if (!m_node->has_parameter("GNSS_LeverArm"))
+				m_node->declare_parameter("GNSS_LeverArm",gnssLeverArm);
 			if(m_node->get_parameter("GNSS_LeverArm", gnssLeverArm))
 			{
 				if (gnssLeverArm.size() != 3)

--- a/src/xsens_mti_ros2_driver/src/xsens_diagnostics.cpp
+++ b/src/xsens_mti_ros2_driver/src/xsens_diagnostics.cpp
@@ -1,0 +1,372 @@
+//  Diagnostics publishing for the Xsens MTi ROS 2 driver.
+//  Distributed under the same BSD license as the rest of this package.
+
+
+#include "xsens_diagnostics.h"
+
+#include <xstypes/xsstatusflag.h>
+
+#include <chrono>
+#include <cmath>
+
+using diagnostic_msgs::msg::DiagnosticStatus;
+
+namespace
+{
+diagnostic_msgs::msg::KeyValue keyValue(const std::string &key, const std::string &value)
+{
+	diagnostic_msgs::msg::KeyValue kv;
+	kv.key = key;
+	kv.value = value;
+	return kv;
+}
+
+std::string toString(double value, int precision = 2)
+{
+	char buffer[32];
+	snprintf(buffer, sizeof(buffer), "%.*f", precision, value);
+	return std::string(buffer);
+}
+
+std::string boolString(bool value)
+{
+	return value ? "true" : "false";
+}
+
+std::string noRotationString(uint32_t status)
+{
+	switch (status & XSF_NoRotationMask)
+	{
+		case 0:
+			return "not running";
+		case XSF_NoRotationSamplesRejected:
+			return "running, samples rejected";
+		case XSF_NoRotationAborted:
+			return "aborted (device moved)";
+		default:
+			return "running normally";
+	}
+}
+
+std::string rtkString(uint32_t status)
+{
+	switch ((status & XSF_RtkStatus) >> 27)
+	{
+		case 0:
+			return "no RTK";
+		case 1:
+			return "RTK float";
+		case 2:
+			return "RTK fixed";
+		default:
+			return "unknown";
+	}
+}
+}  // namespace
+
+XsensDiagnostics::XsensDiagnostics(DriverNode::SharedPtr node)
+	: m_node(node)
+{
+}
+
+void XsensDiagnostics::declareParameters()
+{
+	if (!m_node->has_parameter("diagnostics_enabled"))
+		m_node->declare_parameter("diagnostics_enabled", true);
+	if (!m_node->has_parameter("diagnostics_period"))
+		m_node->declare_parameter("diagnostics_period", 1.0);
+	if (!m_node->has_parameter("diagnostics_min_rate"))
+		m_node->declare_parameter("diagnostics_min_rate", 0.0);
+	if (!m_node->has_parameter("diagnostics_stale_timeout"))
+		m_node->declare_parameter("diagnostics_stale_timeout", 1.0);
+}
+
+void XsensDiagnostics::configure()
+{
+	declareParameters();
+
+	m_node->get_parameter("diagnostics_enabled", m_enabled);
+	m_node->get_parameter("diagnostics_period", m_period);
+	m_node->get_parameter("diagnostics_min_rate", m_minRate);
+	m_node->get_parameter("diagnostics_stale_timeout", m_staleTimeout);
+
+	if (!m_enabled)
+	{
+		RCLCPP_INFO(m_node->get_logger(), "Diagnostics publishing is disabled.");
+		return;
+	}
+
+	if (m_period <= 0.0)
+	{
+		RCLCPP_WARN(m_node->get_logger(),
+					"diagnostics_period must be > 0, got %.3f. Falling back to 1.0 second.", m_period);
+		m_period = 1.0;
+	}
+
+	m_pub = m_node->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
+	RCLCPP_INFO(m_node->get_logger(), "Publishing diagnostics on /diagnostics every %.2f seconds.", m_period);
+}
+
+void XsensDiagnostics::activate()
+{
+	if (!m_enabled || !m_pub)
+		return;
+
+	const auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
+		std::chrono::duration<double>(m_period));
+
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		// Start the rate window fresh so the first report is not skewed by the
+		// time spent inactive.
+		m_lastReportTime = m_node->now();
+		m_hasReportTime = true;
+		m_packetCountAtLastReport = m_packetCount;
+		m_errorCountAtLastReport = m_errorCount;
+	}
+
+	m_timer = m_node->create_wall_timer(period, [this]() { this->publish(); });
+}
+
+void XsensDiagnostics::deactivate()
+{
+	m_timer.reset();
+}
+
+void XsensDiagnostics::cleanup()
+{
+	m_timer.reset();
+	m_pub.reset();
+}
+
+void XsensDiagnostics::setDeviceInfo(const std::string &product_code, const std::string &device_id,
+									 const std::string &firmware, const std::string &port, int baudrate)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_productCode = product_code;
+	m_deviceId = device_id;
+	m_firmware = firmware;
+	m_portName = port;
+	m_baudrate = baudrate;
+}
+
+void XsensDiagnostics::setConnected(bool connected)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_connected = connected;
+}
+
+void XsensDiagnostics::setMeasuring(bool measuring)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_measuring = measuring;
+	if (!measuring)
+	{
+		// Staleness is only meaningful while the device is streaming.
+		m_hasPacketTime = false;
+	}
+}
+
+void XsensDiagnostics::recordPacket(const XsDataPacket &packet)
+{
+	const rclcpp::Time now = m_node->now();
+
+	std::lock_guard<std::mutex> lock(m_mutex);
+	++m_packetCount;
+	m_lastPacketTime = now;
+	m_hasPacketTime = true;
+
+	if (packet.containsStatus())
+	{
+		m_statusWord = packet.status();
+		m_hasStatusWord = true;
+	}
+}
+
+void XsensDiagnostics::recordDeviceError(const std::string &error)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	++m_errorCount;
+	m_lastError = error;
+}
+
+void XsensDiagnostics::publish()
+{
+	if (!m_pub)
+		return;
+
+	const rclcpp::Time now = m_node->now();
+
+	double rate = 0.0;
+	uint32_t errors_in_window = 0;
+	uint32_t status_word = 0;
+	bool has_status_word = false;
+
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+
+		if (m_hasReportTime)
+		{
+			const double elapsed = (now - m_lastReportTime).seconds();
+			if (elapsed > 0.0)
+				rate = static_cast<double>(m_packetCount - m_packetCountAtLastReport) / elapsed;
+		}
+		m_lastReportTime = now;
+		m_hasReportTime = true;
+		m_packetCountAtLastReport = m_packetCount;
+
+		errors_in_window = m_errorCount - m_errorCountAtLastReport;
+		m_errorCountAtLastReport = m_errorCount;
+
+		status_word = m_statusWord;
+		has_status_word = m_hasStatusWord;
+	}
+
+	diagnostic_msgs::msg::DiagnosticArray array;
+	array.header.stamp = now;
+
+	array.status.push_back(deviceStatus(errors_in_window));
+	array.status.push_back(streamStatus(now, rate));
+	if (has_status_word)
+		array.status.push_back(filterStatus(status_word));
+
+	m_pub->publish(array);
+}
+
+diagnostic_msgs::msg::DiagnosticStatus XsensDiagnostics::deviceStatus(uint32_t errors_in_window) const
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	DiagnosticStatus status;
+	status.name = std::string(m_node->get_name()) + ": Device";
+	status.hardware_id = m_deviceId.empty() ? "unknown" : m_deviceId;
+
+	if (!m_connected)
+	{
+		status.level = DiagnosticStatus::ERROR;
+		status.message = "No device connected";
+	}
+	else if (errors_in_window > 0)
+	{
+		status.level = DiagnosticStatus::WARN;
+		status.message = "Device reported an error: " + m_lastError;
+	}
+	else
+	{
+		status.level = DiagnosticStatus::OK;
+		status.message = m_measuring ? "Connected, measuring" : "Connected, not measuring";
+	}
+
+	status.values.push_back(keyValue("Product code", m_productCode));
+	status.values.push_back(keyValue("Device ID", m_deviceId));
+	status.values.push_back(keyValue("Firmware version", m_firmware));
+	status.values.push_back(keyValue("Port", m_portName));
+	status.values.push_back(keyValue("Baudrate", std::to_string(m_baudrate)));
+	status.values.push_back(keyValue("Measuring", boolString(m_measuring)));
+	status.values.push_back(keyValue("Device errors (total)", std::to_string(m_errorCount)));
+	if (!m_lastError.empty())
+		status.values.push_back(keyValue("Last device error", m_lastError));
+
+	return status;
+}
+
+diagnostic_msgs::msg::DiagnosticStatus XsensDiagnostics::streamStatus(const rclcpp::Time &now, double rate)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	DiagnosticStatus status;
+	status.name = std::string(m_node->get_name()) + ": Data stream";
+	status.hardware_id = m_deviceId.empty() ? "unknown" : m_deviceId;
+
+	const double age = m_hasPacketTime ? (now - m_lastPacketTime).seconds() : -1.0;
+
+	if (!m_measuring)
+	{
+		status.level = DiagnosticStatus::OK;
+		status.message = "Idle, device is not in measurement mode";
+	}
+	else if (!m_hasPacketTime)
+	{
+		status.level = DiagnosticStatus::ERROR;
+		status.message = "Measuring but no data received yet";
+	}
+	else if (age > m_staleTimeout)
+	{
+		status.level = DiagnosticStatus::STALE;
+		status.message = "No data for " + toString(age) + " s";
+	}
+	else if (m_minRate > 0.0 && rate < m_minRate)
+	{
+		status.level = DiagnosticStatus::WARN;
+		status.message = "Data rate " + toString(rate, 1) + " Hz is below the configured minimum of " +
+						 toString(m_minRate, 1) + " Hz";
+	}
+	else
+	{
+		status.level = DiagnosticStatus::OK;
+		status.message = "Streaming at " + toString(rate, 1) + " Hz";
+	}
+
+	status.values.push_back(keyValue("Packets received", std::to_string(m_packetCount)));
+	status.values.push_back(keyValue("Rate (Hz)", toString(rate, 1)));
+	status.values.push_back(keyValue("Minimum rate (Hz)", m_minRate > 0.0 ? toString(m_minRate, 1) : "not checked"));
+	status.values.push_back(keyValue("Time since last packet (s)", age < 0.0 ? "n/a" : toString(age, 3)));
+	status.values.push_back(keyValue("Stale timeout (s)", toString(m_staleTimeout)));
+
+	return status;
+}
+
+diagnostic_msgs::msg::DiagnosticStatus XsensDiagnostics::filterStatus(uint32_t status_word) const
+{
+	const bool self_test_ok = (status_word & XSF_SelfTestOk) != 0;
+	const bool orientation_valid = (status_word & XSF_OrientationValid) != 0;
+	const bool gnss_fix = (status_word & XSF_GpsValid) != 0;
+	const bool clipping = (status_word & XSF_ClippingDetected) != 0;
+	const bool clock_synced = (status_word & XSF_ExternalClockSynced) != 0;
+	const bool gnss_time_pulse = (status_word & XSF_HaveGnssTimePulse) != 0;
+
+	DiagnosticStatus status;
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		status.name = std::string(m_node->get_name()) + ": Filter status";
+		status.hardware_id = m_deviceId.empty() ? "unknown" : m_deviceId;
+	}
+
+	// The self test flag is only set right after an explicit self test command,
+	// so it is reported as a value but never drives the level: a healthy MTi
+	// leaves it clear during normal measurement.
+	if (!orientation_valid)
+	{
+		status.level = DiagnosticStatus::WARN;
+		status.message = "Orientation is not valid";
+	}
+	else if (clipping)
+	{
+		status.level = DiagnosticStatus::WARN;
+		status.message = "Sensor data is clipping";
+	}
+	else
+	{
+		status.level = DiagnosticStatus::OK;
+		status.message = "Filter is running";
+	}
+
+	char status_hex[16];
+	snprintf(status_hex, sizeof(status_hex), "0x%08X", status_word);
+
+	status.values.push_back(keyValue("Status word", status_hex));
+	status.values.push_back(keyValue("Self test ok", boolString(self_test_ok)));
+	status.values.push_back(keyValue("Orientation valid", boolString(orientation_valid)));
+	status.values.push_back(keyValue("GNSS fix", boolString(gnss_fix)));
+	status.values.push_back(keyValue("RTK status", rtkString(status_word)));
+	status.values.push_back(keyValue("No rotation update", noRotationString(status_word)));
+	status.values.push_back(keyValue("Clipping detected", boolString(clipping)));
+	status.values.push_back(keyValue("Clipping acc", boolString(anyAccClipped(static_cast<int>(status_word)))));
+	status.values.push_back(keyValue("Clipping gyr", boolString(anyGyrClipped(static_cast<int>(status_word)))));
+	status.values.push_back(keyValue("Clipping mag", boolString(anyMagClipped(static_cast<int>(status_word)))));
+	status.values.push_back(keyValue("Filter mode", std::to_string((status_word & XSF_FilterMode) >> 23)));
+	status.values.push_back(keyValue("External clock synced", boolString(clock_synced)));
+	status.values.push_back(keyValue("GNSS time pulse", boolString(gnss_time_pulse)));
+
+	return status;
+}

--- a/src/xsens_mti_ros2_driver/src/xsens_mti_lifecycle_node.cpp
+++ b/src/xsens_mti_ros2_driver/src/xsens_mti_lifecycle_node.cpp
@@ -1,0 +1,160 @@
+//  Managed (lifecycle) node wrapper for the Xsens MTi ROS 2 driver.
+//  Distributed under the same BSD license as the rest of this package.
+
+
+#include "xsens_mti_lifecycle_node.h"
+
+#include "xdainterface.h"
+#include "xsens_diagnostics.h"
+
+using CallbackReturn = XsensMtiLifecycleNode::CallbackReturn;
+
+XsensMtiLifecycleNode::XsensMtiLifecycleNode(const rclcpp::NodeOptions &options)
+	: DriverNode("xsens_driver", options)
+{
+	if (!has_parameter("autostart"))
+		declare_parameter("autostart", true);
+}
+
+XsensMtiLifecycleNode::~XsensMtiLifecycleNode()
+{
+	releaseDevice();
+}
+
+bool XsensMtiLifecycleNode::autostart() const
+{
+	bool autostart = true;
+	get_parameter("autostart", autostart);
+	return autostart;
+}
+
+bool XsensMtiLifecycleNode::isActive() const
+{
+	return m_active;
+}
+
+void XsensMtiLifecycleNode::pumpDeviceData(std::chrono::milliseconds timeout)
+{
+	if (m_active && m_interface)
+		m_interface->spinFor(timeout);
+}
+
+void XsensMtiLifecycleNode::shutdownDriver()
+{
+	if (m_active && m_interface)
+		m_interface->stopMeasurement();
+
+	releaseDevice();
+}
+
+void XsensMtiLifecycleNode::releaseDevice()
+{
+	m_active = false;
+
+	// Destroying the interface closes the log file, releases the port and
+	// destroys the message publishers.
+	m_interface.reset();
+
+	if (m_diagnostics)
+	{
+		m_diagnostics->cleanup();
+		m_diagnostics.reset();
+	}
+}
+
+CallbackReturn XsensMtiLifecycleNode::on_configure(const rclcpp_lifecycle::State &)
+{
+	RCLCPP_INFO(get_logger(), "Configuring ...");
+
+	m_diagnostics = std::make_shared<XsensDiagnostics>(shared_from_this());
+	m_diagnostics->configure();
+
+	m_interface = std::make_shared<XdaInterface>(shared_from_this());
+	m_interface->setDiagnostics(m_diagnostics);
+
+	if (!m_interface->connectDevice())
+	{
+		RCLCPP_ERROR(get_logger(), "Failed to connect device");
+		releaseDevice();
+		return CallbackReturn::FAILURE;
+	}
+
+	// Publishers are created here and stay deactivated until the node is
+	// activated, so no data reaches the wire before then.
+	m_interface->registerPublishers();
+
+	if (!m_interface->configureDevice())
+	{
+		RCLCPP_ERROR(get_logger(), "Failed to configure device");
+		releaseDevice();
+		return CallbackReturn::FAILURE;
+	}
+
+	RCLCPP_INFO(get_logger(), "Configured.");
+	return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn XsensMtiLifecycleNode::on_activate(const rclcpp_lifecycle::State &previous_state)
+{
+	RCLCPP_INFO(get_logger(), "Activating ...");
+
+	// Activates every lifecycle publisher created during configuration.
+	DriverNode::on_activate(previous_state);
+
+	if (!m_interface || !m_interface->startMeasurement())
+	{
+		RCLCPP_ERROR(get_logger(), "Failed to put the device into measurement mode");
+		DriverNode::on_deactivate(previous_state);
+		return CallbackReturn::FAILURE;
+	}
+
+	m_diagnostics->activate();
+	m_active = true;
+
+	RCLCPP_INFO(get_logger(), "Activated.");
+	return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn XsensMtiLifecycleNode::on_deactivate(const rclcpp_lifecycle::State &previous_state)
+{
+	RCLCPP_INFO(get_logger(), "Deactivating ...");
+
+	m_active = false;
+
+	if (m_diagnostics)
+		m_diagnostics->deactivate();
+	if (m_interface)
+		m_interface->stopMeasurement();
+
+	// Deactivates every lifecycle publisher created during configuration.
+	DriverNode::on_deactivate(previous_state);
+
+	RCLCPP_INFO(get_logger(), "Deactivated.");
+	return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn XsensMtiLifecycleNode::on_cleanup(const rclcpp_lifecycle::State &)
+{
+	RCLCPP_INFO(get_logger(), "Cleaning up ...");
+	releaseDevice();
+	return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn XsensMtiLifecycleNode::on_shutdown(const rclcpp_lifecycle::State &previous_state)
+{
+	RCLCPP_INFO(get_logger(), "Shutting down ...");
+
+	// Leaves the publishers deactivated if we were shut down while active.
+	DriverNode::on_deactivate(previous_state);
+
+	shutdownDriver();
+
+	return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn XsensMtiLifecycleNode::on_error(const rclcpp_lifecycle::State &)
+{
+	RCLCPP_ERROR(get_logger(), "A lifecycle transition failed, releasing the device.");
+	releaseDevice();
+	return CallbackReturn::SUCCESS;
+}


### PR DESCRIPTION
## Summary

Turns the driver into a managed (lifecycle) node and adds diagnostics publishing on `/diagnostics`.

**Lifecycle.** The transitions map onto the device: `configure` opens the port, reads the device information, creates the publishers and applies the device configuration; `activate` puts the device into measurement mode; `deactivate` returns it to config mode; `cleanup` closes the port. Every message publisher is now a lifecycle publisher, so nothing reaches the wire while the node is inactive.

Backwards compatible by default: the new `autostart` parameter defaults to `true`, so the node walks itself into the active state on startup and `ros2 run` / `xsens_mti_node.launch.py` behave exactly as before. Set `autostart:=false` to drive the transitions with `ros2 lifecycle set`.

**Diagnostics.** While active, the node publishes `diagnostic_msgs/DiagnosticArray` on `/diagnostics` with three statuses:

- **Device** — product code, device ID, firmware version, port, baudrate and the number of errors reported by the device.
- **Data stream** — packets received, measured rate and time since the last packet. WARN below `diagnostics_min_rate`, STALE after `diagnostics_stale_timeout` seconds without data.
- **Filter status** — the MTi status word decoded into orientation validity, GNSS fix, RTK status, clipping flags, no-rotation-update state, filter mode and clock sync.

Configured via `diagnostics_enabled`, `diagnostics_period`, `diagnostics_min_rate` and `diagnostics_stale_timeout`, documented in both param YAMLs and in both READMEs.

## Supporting fixes

These were needed to make the transitions repeatable, and are latent bugs in their own right:

- `XdaInterface::close()` now releases the port it actually opened. `m_port` was never assigned, so `closePort()` was a no-op and a cleanup/configure cycle could not re-open the device.
- Registered packet callbacks are deleted on close, and `PacketCallback` gained a virtual destructor.
- Parameter declarations that ran unguarded are now guarded with `has_parameter()`, so re-configuring after cleanup no longer throws `ParameterAlreadyDeclared`.
- SIGINT/SIGTERM are handled by the node so the shutdown transition runs on a valid context and the device leaves measurement mode in an orderly way.

## Build fixes for newer ROS 2 releases (unrelated to the feature)

The workspace did not build on Rolling before this PR. These fixes are written so that older releases keep working unchanged:

- `ament_target_dependencies()` no longer exists on Rolling. Both `src/xsens_mti_ros2_driver/CMakeLists.txt` and `src/ntrip/CMakeLists.txt` now fall back to linking the exported CMake targets directly, guarded with `if(COMMAND ament_target_dependencies)`.
- `tf2/LinearMath/Quaternion.h` is only installed as `.hpp`, selected with `__has_include`.

With these, `colcon build` completes both `xsens_mti_ros2_driver` and `ntrip` on Rolling.

## Testing

Verified against an MTi-680G on `/dev/ttyUSB0` at 921600 baud, at both **100 Hz and 400 Hz** output rates:

- `autostart` brings the node to `active` and streams as before.
- Full transition cycle: configure → activate → deactivate → activate → cleanup → configure → activate, all successful, including the port being released and re-opened.
- At 400 Hz: `/imu/data`, `/imu/angular_velocity`, `/imu/acceleration` and `/filter/quaternion` all measured at 401 Hz, diagnostics reporting 401.8 Hz with 0 device errors and no data overflow.
- Topics confirmed silent while the node is inactive.
- Clean SIGINT shutdown: leaves measurement mode, closes the port, process exits.

The device was reconfigured to 400 Hz for the test and restored to its original 100 Hz configuration afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
